### PR TITLE
Fix FBR-206 - Antiguo No. Grupo no es obligatorio

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/centerGroup/service/CenterGroupReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/centerGroup/service/CenterGroupReadPlatformServiceImpl.java
@@ -151,7 +151,8 @@ public class CenterGroupReadPlatformServiceImpl implements CenterGroupReadPlatfo
 
             final Long id = rs.getLong("id");
             final String name = rs.getString("name");
-            final Long legacyGroupNumber = rs.getLong("legacyGroupNumber");
+            Long legacyGroupNumber = rs.getLong("legacyGroupNumber");
+            legacyGroupNumber = rs.wasNull() ? null : legacyGroupNumber;
 
             final Long portfolioCenterId = rs.getLong("portfolioCenterId");
             final String portfolioCenterName = rs.getString("portfolioCenterName");


### PR DESCRIPTION
Fix FBR-206 - Cuando se edita un grupo, Antiguo No. Grupo no es obligatorio

## Description

Check null on this field and return null instead of zero as default value.


## Checklist

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Write the commit message as per https://github.com/apache/fineract/#pull-requests

- [ ] Acknowledge that we will not review PRs that are not passing the build _("green")_ - it is your responsibility to get a proposed PR to pass the build, not primarily the project's maintainers.

- [ ] Create/update unit or integration tests for verifying the changes made.

- [ ] Follow coding conventions at https://cwiki.apache.org/confluence/display/FINERACT/Coding+Conventions.

- [ ] Add required Swagger annotation and update API documentation at fineract-provider/src/main/resources/static/legacy-docs/apiLive.htm with details of any API changes

- [ ] Submission is not a "code dump".  (Large changes can be made "in repository" via a branch.  Ask on the developer mailing list for guidance, if required.)

FYI our guidelines for code reviews are at https://cwiki.apache.org/confluence/display/FINERACT/Code+Review+Guide.
