### PR TITLE
SU-550: Calculate accrued interest based on outstanding interest

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanWritePlatformServiceJpaRepositoryImpl.java
@@ -4768,7 +4768,7 @@ public class LoanWritePlatformServiceJpaRepositoryImpl implements LoanWritePlatf
                             .getAccruedInterestForInstallment(loanRepaymentScheduleInstallment.getInstallmentNumber());
                     long daysInPeriod = Math.toIntExact(ChronoUnit.DAYS.between(loanRepaymentScheduleInstallment.getFromDate(),
                             loanRepaymentScheduleInstallment.getDueDate()));
-                    Money interestForInstallment = loanRepaymentScheduleInstallment.getInterestCharged(currency);
+                    Money interestForInstallment = loanRepaymentScheduleInstallment.getInterestOutstanding(currency);
                     // Adjust interest on the last day of the period to make up the difference
                     if (transactionDate.equals(loanRepaymentScheduleInstallment.getDueDate().minusDays(1))) {
                         // if the amount is whole number when divided across the days in the period, then do same for


### PR DESCRIPTION
SU-550: Calculate accrued interest based on outstanding interest.

The issue found here is that the daily interest accrual is calculated based on the interest charged for the instalment divided by the number of days in the instalment period. So if a payment is made it was still considering the original interest for the instalment to calculate the daily accrual.

The change I have made is that if a payment has been made that impacts the interest, then the daily accrual should also be adjusted according to the outstanding interest for that instalment