### PR TITLE
Bug/SU-635: the impuesto field must go to null instead of 0 if the impuesto_item is null

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/invoice/domain/FacturaElectronicaMensual.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/invoice/domain/FacturaElectronicaMensual.java
@@ -338,4 +338,12 @@ public class FacturaElectronicaMensual extends AbstractPersistableCustom impleme
             this.impuesto_item = impuesto_item;
         }
     }
+
+    public void setImpuesto(BigDecimal impuestoValue) {
+        if (impuestoValue != null && impuestoValue.compareTo(BigDecimal.ZERO) == 0) {
+            this.impuesto = null;
+        } else {
+            this.impuesto = impuestoValue;
+        }
+    }
 }


### PR DESCRIPTION
…puesto_item is null

## Description

Describe the changes made and why they were made.
https://fiterio.atlassian.net/browse/SU-635
