### PR TITLE
Feature/SU-707: Fix Loan not getting closed to zero balance

### DIFF
--- a/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanRepaymentScheduleInstallment.java
+++ b/fineract-loan/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanRepaymentScheduleInstallment.java
@@ -333,7 +333,8 @@ public class LoanRepaymentScheduleInstallment extends AbstractAuditableWithUTCDa
     public Money getPrincipalOutstandingIncludingAdvanced(final MonetaryCurrency currency) {
         final Money principalAccountedFor = getPrincipalCompleted(currency).plus(getPrincipalWrittenOff(currency))
                 .plus(getAdvancePrincipalAmount());
-        return getPrincipal(currency).minus(principalAccountedFor);
+        final Money principalOutstandingIncludingAdvanced = getPrincipal(currency).minus(principalAccountedFor);
+        return principalOutstandingIncludingAdvanced.isLessThanZero() ? Money.zero(currency) : principalOutstandingIncludingAdvanced;
     }
 
     public Money getInterestCharged(final MonetaryCurrency currency) {


### PR DESCRIPTION
## Description
The repayment installment are getting marked prematurely as fully paid because the method getTotalOutstandingIncludingAdvanced was returning a negative value causing inconsistency in the allocation of the different transaction portion during loan foreclosure event