### PR TITLE
Feature/puente al exito

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/api/AuthenticationApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/api/AuthenticationApiResource.java
@@ -105,8 +105,7 @@ public class AuthenticationApiResource {
             @Qualifier("customAuthenticationProvider") final DaoAuthenticationProvider customAuthenticationProvider,
             final ToApiJsonSerializer<AuthenticatedUserData> apiJsonSerializerService,
             final SpringSecurityPlatformSecurityContext springSecurityPlatformSecurityContext,
-            ClientReadPlatformService aClientReadPlatformService,
-            DefaultToApiJsonSerializer<Map<String, Object>> toApiJsonSerializer,
+            ClientReadPlatformService aClientReadPlatformService, DefaultToApiJsonSerializer<Map<String, Object>> toApiJsonSerializer,
             PortfolioCommandSourceWritePlatformService commandsSourceWritePlatformService,
             final PlatformPasswordEncoder platformPasswordEncoder, final JdbcTemplate jdbcTemplate,
             final AppUserWritePlatformService appUserWritePlatformService) {

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/api/AuthenticationApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/api/AuthenticationApiResource.java
@@ -54,7 +54,6 @@ import org.apache.fineract.infrastructure.security.data.AuthenticatedUserData;
 import org.apache.fineract.infrastructure.security.exception.TWOFAEmailConfigurationException;
 import org.apache.fineract.infrastructure.security.service.PlatformPasswordEncoder;
 import org.apache.fineract.infrastructure.security.service.SpringSecurityPlatformSecurityContext;
-import org.apache.fineract.infrastructure.security.service.TwoFactorService;
 import org.apache.fineract.portfolio.client.service.ClientReadPlatformService;
 import org.apache.fineract.useradministration.data.RoleData;
 import org.apache.fineract.useradministration.domain.AppUser;
@@ -96,7 +95,6 @@ public class AuthenticationApiResource {
     private final SpringSecurityPlatformSecurityContext springSecurityPlatformSecurityContext;
     private final ClientReadPlatformService clientReadPlatformService;
     private final DefaultToApiJsonSerializer<Map<String, Object>> toApiJsonSerializer;
-    private final TwoFactorService twoFactorService;
     private final PortfolioCommandSourceWritePlatformService commandsSourceWritePlatformService;
     private final PlatformPasswordEncoder platformPasswordEncoder;
     private final JdbcTemplate jdbcTemplate;
@@ -107,7 +105,7 @@ public class AuthenticationApiResource {
             @Qualifier("customAuthenticationProvider") final DaoAuthenticationProvider customAuthenticationProvider,
             final ToApiJsonSerializer<AuthenticatedUserData> apiJsonSerializerService,
             final SpringSecurityPlatformSecurityContext springSecurityPlatformSecurityContext,
-            ClientReadPlatformService aClientReadPlatformService, TwoFactorService twoFactorService,
+            ClientReadPlatformService aClientReadPlatformService,
             DefaultToApiJsonSerializer<Map<String, Object>> toApiJsonSerializer,
             PortfolioCommandSourceWritePlatformService commandsSourceWritePlatformService,
             final PlatformPasswordEncoder platformPasswordEncoder, final JdbcTemplate jdbcTemplate,
@@ -117,7 +115,6 @@ public class AuthenticationApiResource {
         this.springSecurityPlatformSecurityContext = springSecurityPlatformSecurityContext;
         this.clientReadPlatformService = aClientReadPlatformService;
         this.toApiJsonSerializer = toApiJsonSerializer;
-        this.twoFactorService = twoFactorService;
         this.commandsSourceWritePlatformService = commandsSourceWritePlatformService;
         this.platformPasswordEncoder = platformPasswordEncoder;
         this.jdbcTemplate = jdbcTemplate;
@@ -230,9 +227,9 @@ public class AuthenticationApiResource {
             @QueryParam("logoutDevices") @DefaultValue(value = "false") final Boolean logoutDevices,
             @QueryParam("username") String username, @QueryParam("otp") String otp) {
         if (command.equalsIgnoreCase("requestPasswordReset")) {
-            this.twoFactorService.requestPasswordReset(username);
+            this.appUserWritePlatformService.requestPasswordReset(username);
         } else if (command.equalsIgnoreCase("resetPassword")) {
-            this.twoFactorService.completePasswordReset(username, otp, logoutDevices, platformPasswordEncoder);
+            this.appUserWritePlatformService.completePasswordReset(username, otp, logoutDevices, platformPasswordEncoder);
         } else {
             throw new IllegalArgumentException("The command " + command + " is not supported.");
 
@@ -247,7 +244,7 @@ public class AuthenticationApiResource {
     @Produces({ MediaType.APPLICATION_JSON })
     public String update(@PathParam("userId") @Parameter(description = "userId") final Long userId,
             @Parameter(hidden = true) final String apiRequestBodyAsJson) {
-        AppUser appUser = this.twoFactorService.selfResetUserPassword(userId, apiRequestBodyAsJson, platformPasswordEncoder);
+        AppUser appUser = this.appUserWritePlatformService.selfResetUserPassword(userId, apiRequestBodyAsJson, platformPasswordEncoder);
         AuthenticatedUserData authenticatedUserData = new AuthenticatedUserData(appUser.getUsername(), null);
         return this.toApiJsonSerializer.serialize(authenticatedUserData);
     }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/domain/OTPRequestRepository.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/domain/OTPRequestRepository.java
@@ -21,12 +21,10 @@ package org.apache.fineract.infrastructure.security.domain;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.fineract.infrastructure.security.data.OTPRequest;
 import org.apache.fineract.useradministration.domain.AppUser;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Repository;
 import org.springframework.util.Assert;
 
 @Repository
-@ConditionalOnProperty("fineract.security.2fa.enabled")
 @SuppressWarnings({ "MemberName" })
 public class OTPRequestRepository {
 

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/domain/TFAccessTokenRepository.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/domain/TFAccessTokenRepository.java
@@ -20,11 +20,9 @@ package org.apache.fineract.infrastructure.security.domain;
 
 import java.util.List;
 import org.apache.fineract.useradministration.domain.AppUser;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
-@ConditionalOnProperty("fineract.security.2fa.enabled")
 public interface TFAccessTokenRepository extends JpaRepository<TFAccessToken, Long>, JpaSpecificationExecutor<TFAccessToken> {
 
     TFAccessToken findByUserAndToken(AppUser user, String token);

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/domain/TwoFactorConfigurationRepository.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/domain/TwoFactorConfigurationRepository.java
@@ -19,11 +19,10 @@
 package org.apache.fineract.infrastructure.security.domain;
 
 import java.util.List;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
-@ConditionalOnProperty("fineract.security.2fa.enabled")
 public interface TwoFactorConfigurationRepository
         extends JpaRepository<TwoFactorConfiguration, Long>, JpaSpecificationExecutor<TwoFactorConfiguration> {
 

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/domain/TwoFactorConfigurationRepository.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/domain/TwoFactorConfigurationRepository.java
@@ -19,7 +19,6 @@
 package org.apache.fineract.infrastructure.security.domain;
 
 import java.util.List;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/service/TwoFactorConfigurationServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/service/TwoFactorConfigurationServiceImpl.java
@@ -36,13 +36,11 @@ import org.apache.fineract.infrastructure.security.domain.TwoFactorConfiguration
 import org.apache.fineract.infrastructure.security.domain.TwoFactorConfigurationRepository;
 import org.apache.fineract.useradministration.domain.AppUser;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 @Service
-@ConditionalOnProperty("fineract.security.2fa.enabled")
 public class TwoFactorConfigurationServiceImpl implements TwoFactorConfigurationService {
 
     private static final String DEFAULT_EMAIL_SUBJECT = "Fineract Two-Factor Authentication Token";

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/service/TwoFactorService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/service/TwoFactorService.java
@@ -41,9 +41,4 @@ public interface TwoFactorService {
 
     void updateRegisteredDevices(AppUser user, String fingerprint);
 
-    AppUser requestPasswordReset(String username);
-
-    AppUser completePasswordReset(String username, String otp, Boolean logoutDevices, PlatformPasswordEncoder platformPasswordEncoder);
-
-    AppUser selfResetUserPassword(Long userId, String requestData, PlatformPasswordEncoder platformPasswordEncoder);
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/service/TwoFactorServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/service/TwoFactorServiceImpl.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
 import org.apache.fineract.infrastructure.core.domain.EmailDetail;

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/service/TwoFactorServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/security/service/TwoFactorServiceImpl.java
@@ -18,24 +18,19 @@
  */
 package org.apache.fineract.infrastructure.security.service;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
 import org.apache.fineract.infrastructure.core.domain.EmailDetail;
-import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
 import org.apache.fineract.infrastructure.core.service.PlatformEmailService;
 import org.apache.fineract.infrastructure.security.constants.TwoFactorConstants;
 import org.apache.fineract.infrastructure.security.data.OTPDeliveryMethod;
 import org.apache.fineract.infrastructure.security.data.OTPRequest;
-import org.apache.fineract.infrastructure.security.domain.BasicPasswordEncodablePlatformUser;
 import org.apache.fineract.infrastructure.security.domain.OTPRequestRepository;
-import org.apache.fineract.infrastructure.security.domain.PlatformUser;
 import org.apache.fineract.infrastructure.security.domain.TFAccessToken;
 import org.apache.fineract.infrastructure.security.domain.TFAccessTokenRepository;
 import org.apache.fineract.infrastructure.security.exception.AccessTokenInvalidIException;
@@ -49,14 +44,12 @@ import org.apache.fineract.useradministration.domain.AppUserDevices;
 import org.apache.fineract.useradministration.domain.AppUserDevicesRepository;
 import org.apache.fineract.useradministration.domain.AppUserRepository;
 import org.apache.fineract.useradministration.exception.DevicesLimitException;
-import org.apache.fineract.useradministration.exception.UserNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.CachePut;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -71,7 +64,6 @@ public class TwoFactorServiceImpl implements TwoFactorService {
     private final AppUserDevicesRepository appUserDevicesRepository;
     private final AppUserRepository appUserRepository;
     private final SmsMessageRepository smsMessageRepository;
-    private final FromJsonHelper fromApiJsonHelper;
     private final TwoFactorConfigurationService configurationService;
     private final JdbcTemplate jdbcTemplate;
 
@@ -80,7 +72,7 @@ public class TwoFactorServiceImpl implements TwoFactorService {
             SmsMessageScheduledJobService smsMessageScheduledJobService, OTPRequestRepository otpRequestRepository,
             TFAccessTokenRepository tfAccessTokenRepository, SmsMessageRepository smsMessageRepository,
             TwoFactorConfigurationService configurationService, final AppUserDevicesRepository appUserDevicesRepository,
-            AppUserRepository appUserRepository, FromJsonHelper fromApiJsonHelper, JdbcTemplate jdbcTemplate) {
+            AppUserRepository appUserRepository, JdbcTemplate jdbcTemplate) {
         this.accessTokenGenerationService = accessTokenGenerationService;
         this.emailService = emailService;
         this.smsMessageScheduledJobService = smsMessageScheduledJobService;
@@ -90,7 +82,6 @@ public class TwoFactorServiceImpl implements TwoFactorService {
         this.configurationService = configurationService;
         this.appUserDevicesRepository = appUserDevicesRepository;
         this.appUserRepository = appUserRepository;
-        this.fromApiJsonHelper = fromApiJsonHelper;
         this.jdbcTemplate = jdbcTemplate;
     }
 
@@ -209,77 +200,6 @@ public class TwoFactorServiceImpl implements TwoFactorService {
             AppUserDevices newDevice = AppUserDevices.createNew(user, fingerprint);
             appUserDevicesRepository.save(newDevice);
         }
-    }
-
-    @Override
-    public AppUser requestPasswordReset(String username) {
-        AppUser appUserByName = this.appUserRepository.findAppUserByName(username);
-        if (appUserByName == null) {
-            throw new UsernameNotFoundException(username);
-        }
-        OTPRequest request = createNewOTPToken(appUserByName, TwoFactorConstants.EMAIL_DELIVERY_METHOD_NAME, false);
-
-        return appUserByName;
-    }
-
-    @Override
-    public AppUser completePasswordReset(String username, String otp, Boolean logoutDevices,
-            PlatformPasswordEncoder platformPasswordEncoder) {
-        AppUser appUser = this.appUserRepository.findAppUserByName(username);
-        if (appUser == null) {
-            throw new UsernameNotFoundException(username);
-        }
-        OTPRequest otpRequest = otpRequestRepository.getOTPRequestForUser(appUser);
-        if (otpRequest == null || !otpRequest.isValid() || !otpRequest.getToken().equalsIgnoreCase(otp)) {
-            throw new OTPTokenInvalidException();
-        }
-        otpRequestRepository.deleteOTPRequestForUser(appUser);
-        String newPassword = this.accessTokenGenerationService.generateRandomToken().substring(0, 8);
-
-        final PlatformUser dummyPlatformUser = new BasicPasswordEncodablePlatformUser(appUser.getId(), "", newPassword);
-        String encodedPass = platformPasswordEncoder.encode(dummyPlatformUser);
-
-        this.jdbcTemplate.update("UPDATE m_appuser SET reset_password = ?, password=?, nonlocked=true WHERE id = ?", true, encodedPass,
-                appUser.getId());
-
-        final String emailSubject = "Password Reset Successful";
-        final String emailBody = "Your password has been reset. Your new password is: " + newPassword;
-        final EmailDetail emailData = new EmailDetail(emailSubject, emailBody, appUser.getEmail(),
-                appUser.getFirstname() + " " + appUser.getLastname());
-        emailService.sendDefinedEmail(emailData);
-
-        if (logoutDevices) {
-            this.appUserDevicesRepository.findByUser(appUser).forEach(device -> {
-                this.appUserDevicesRepository.delete(device);
-            });
-        }
-        List<TFAccessToken> tfAccessTokens = this.tfAccessTokenRepository.findByUser(appUser);
-        tfAccessTokens.forEach(token -> {
-            this.tfAccessTokenRepository.delete(token);
-        });
-
-        return appUser;
-    }
-
-    @Override
-    public AppUser selfResetUserPassword(Long userId, String requestData, PlatformPasswordEncoder platformPasswordEncoder) {
-        Optional<AppUser> appUserOptional = this.appUserRepository.findById(userId);
-        if (appUserOptional.isEmpty()) throw new UserNotFoundException(userId);
-        AppUser appUser = appUserOptional.get();
-        JsonElement jsonElement = this.fromApiJsonHelper.parse(requestData);
-        JsonObject asJsonObject = jsonElement.getAsJsonObject();
-        if (jsonElement.isJsonObject()) {
-            String password = this.fromApiJsonHelper.extractStringNamed("password", jsonElement);
-            String passwordRepeat = this.fromApiJsonHelper.extractStringNamed("repeatPassword", jsonElement);
-            final String jsonCommand = asJsonObject.toString();
-            final JsonCommand command = JsonCommand.from(jsonCommand, asJsonObject, this.fromApiJsonHelper, null, userId, null, null, null,
-                    null, null, null, null, null, null, null);
-            final String passwordEncodedValue = command.passwordValueOfParameterNamed("password", platformPasswordEncoder, appUser.getId());
-            appUser.updatePassword(passwordEncodedValue);
-            appUser.updateResetPassword(false);
-            this.appUserRepository.save(appUser);
-        }
-        return appUser;
     }
 
     @Override

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/committee/data/CommitteeApprovalsData.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/committee/data/CommitteeApprovalsData.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fineract.organisation.committee.data;
+
+import lombok.Builder;
+import lombok.Data;
+import org.apache.fineract.infrastructure.core.data.EnumOptionData;
+
+import java.math.BigDecimal;
+
+/**
+ * Created by brian on 03/11/2025.
+ */
+@Data
+@Builder
+public class CommitteeApprovalsData {
+    private EnumOptionData approvalData;
+    private BigDecimal fromAmount;
+    private BigDecimal toAmount;
+    private Long id;
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/committee/data/CommitteeData.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/committee/data/CommitteeData.java
@@ -21,6 +21,7 @@ package org.apache.fineract.organisation.committee.data;
 import java.util.ArrayList;
 import java.util.Collection;
 import org.apache.fineract.infrastructure.codes.data.CodeValueData;
+import org.apache.fineract.organisation.committee.domain.CommitteeApprovalLimits;
 
 /**
  * Immutable data object for committee data.
@@ -32,6 +33,7 @@ public class CommitteeData {
     private final String name;
 
     private Collection<CommitteeUserData> selectedUsers;
+    private Collection<CommitteeApprovalLimits> committeeApprovalLimits;
 
     // template
     private final Collection<CodeValueData> committees;
@@ -66,4 +68,7 @@ public class CommitteeData {
         this.availableUsers = availableUsers;
     }
 
+    public void setCommitteeApprovalLimits(Collection<CommitteeApprovalLimits> committeeApprovalLimits) {
+        this.committeeApprovalLimits = committeeApprovalLimits;
+    }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/committee/domain/CommitteeApprovalLimits.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/committee/domain/CommitteeApprovalLimits.java
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.organisation.committee.domain;
+
+import lombok.Getter;
+import org.apache.fineract.infrastructure.core.domain.AbstractPersistableCustom;
+import org.apache.fineract.infrastructure.core.service.DateUtils;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Table(name = "committee_approval_limits", uniqueConstraints = { @UniqueConstraint(columnNames = { "committee_id" }, name = "user_id") })
+public class CommitteeApprovalLimits extends AbstractPersistableCustom {
+
+    @Column(name = "committee_id")
+    private Long committee;
+
+    @Column(name = "from_amount")
+    private BigDecimal fromAmount;
+
+    @Column(name = "to_amount")
+    private BigDecimal toAmount;
+
+    @Column(name = "condition")
+    private String condition;
+
+    @Column(name = "limit")
+    private Integer limit;
+
+    @Column(name = "created_at")
+    private LocalDateTime dateCreated;
+
+    @Column(name = "created_by")
+    private Long createdBy;
+
+
+    protected CommitteeApprovalLimits() {
+        //
+    }
+
+    public CommitteeApprovalLimits(Long committee, BigDecimal fromAmount, BigDecimal toAmount, String condition, Integer limit, Long createdBy) {
+        this.committee = committee;
+        this.fromAmount = fromAmount;
+        this.toAmount = toAmount;
+        this.condition = condition;
+        this.limit = limit;
+        this.dateCreated = DateUtils.getLocalDateTimeOfSystem();
+        this.createdBy = createdBy;
+    }
+
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/committee/domain/CommitteeApprovalLimitsRepository.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/committee/domain/CommitteeApprovalLimitsRepository.java
@@ -16,20 +16,20 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.fineract.organisation.prequalification.domain;
+package org.apache.fineract.organisation.committee.domain;
 
-import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-public interface PreQualificationStatusLogRepository
-        extends JpaRepository<PrequalificationStatusLog, Long>, JpaSpecificationExecutor<PrequalificationStatusLog> {
+import java.util.List;
 
-    @Query("SELECT sl FROM PrequalificationStatusLog sl WHERE sl.prequalificationGroup = :preqGroup AND sl.toStatus = :status ORDER BY sl.id desc")
-    List<PrequalificationStatusLog> groupStatusLogs(@Param("status") Integer status, @Param("preqGroup") PrequalificationGroup preqGroup);
+public interface CommitteeApprovalLimitsRepository extends JpaRepository<CommitteeApprovalLimits, Long>, JpaSpecificationExecutor<CommitteeApprovalLimits> {
 
-    @Query("SELECT sl FROM PrequalificationStatusLog sl WHERE sl.prequalificationGroup.id = :preqGroup ORDER BY sl.id desc")
-    List<PrequalificationStatusLog> groupStatusLogs(@Param("preqGroup") Long preqGroup);
+    List<CommitteeApprovalLimits> getCommitteeApprovalLimitsByCommittee(Long committeeId);
+
+    @Modifying
+    @Query("delete from CommitteeApprovalLimits c where c.committee = :committee")
+    void deleteByCommittee(Long committee);
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/committee/domain/CommitteeApprovalLimitsRepositoryWrapper.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/committee/domain/CommitteeApprovalLimitsRepositoryWrapper.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.organisation.committee.domain;
+
+import org.apache.fineract.organisation.committee.exception.CommitteeNotFoundException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * <p>
+ * Wrapper for {@link CommitteeRepository} that adds NULL checking and Error handling capabilities
+ * </p>
+ */
+@Service
+public class CommitteeApprovalLimitsRepositoryWrapper {
+
+    private final CommitteeApprovalLimitsRepository repository;
+
+    @Autowired
+    public CommitteeApprovalLimitsRepositoryWrapper(final CommitteeApprovalLimitsRepository repository) {
+        this.repository = repository;
+    }
+
+    public CommitteeApprovalLimits findOneWithNotFoundDetection(final Long id) {
+        return this.repository.findById(id).orElseThrow(() -> new CommitteeNotFoundException(id));
+    }
+
+    public CommitteeApprovalLimits save(final CommitteeApprovalLimits entity) {
+        return this.repository.save(entity);
+    }
+
+    public CommitteeApprovalLimits saveAndFlush(final CommitteeApprovalLimits entity) {
+        return this.repository.saveAndFlush(entity);
+    }
+
+    public void delete(final CommitteeApprovalLimits entity) {
+        this.repository.delete(entity);
+    }
+
+    public void deleteByCommittee(final Long committeeId) {
+        this.repository.deleteByCommittee(committeeId);
+    }
+
+    public List<CommitteeApprovalLimits> getApprovallimitsByCommittee(final Long committeeId) {
+        return this.repository.getCommitteeApprovalLimitsByCommittee(committeeId);
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/committee/mappers/RequiredCommitteeApprovalsMapper.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/committee/mappers/RequiredCommitteeApprovalsMapper.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.fineract.organisation.committee.mappers;
+import org.apache.fineract.infrastructure.core.data.EnumOptionData;
+import org.apache.fineract.infrastructure.core.domain.JdbcSupport;
+import org.apache.fineract.organisation.committee.data.CommitteeApprovalsData;
+import org.apache.fineract.organisation.prequalification.domain.PreQualificationsEnumerations;
+import org.springframework.jdbc.core.RowMapper;
+
+import java.math.BigDecimal;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+public class RequiredCommitteeApprovalsMapper implements RowMapper<CommitteeApprovalsData> {
+
+        private final String schema;
+
+        public RequiredCommitteeApprovalsMapper() {
+            this.schema = """
+                    c.id,c.from_amount, c.to_amount, cv.code_value
+                    from committee_approval_limits c 
+                    join m_code_value cv on cv.id = c.committee_id
+                    """;
+        }
+
+        public String schema() {
+            return this.schema;
+        }
+
+        @Override
+        public CommitteeApprovalsData mapRow(final ResultSet rs, final int rowNum) throws SQLException {
+
+            final Integer statusEnum = JdbcSupport.getInteger(rs, "status");
+            final Integer bureauStatus = rs.getInt("buroCheckStatus");
+            final Long id = JdbcSupport.getLong(rs, "id");
+            final BigDecimal nombre = rs.getBigDecimal("from_amount");
+            final BigDecimal tipo = rs.getBigDecimal("to_amount");
+            final String committeeValue = rs.getString("code_value");
+            final EnumOptionData status = PreQualificationsEnumerations.status(committeeValue);
+
+            CommitteeApprovalsData committeeApprovalsData = CommitteeApprovalsData.builder()
+                    .id(id)
+                    .fromAmount(nombre)
+                    .toAmount(tipo)
+                    .approvalData(status)
+                    .build();
+            return committeeApprovalsData;
+        }
+    }

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/committee/serialization/CommitteeCommandFromApiJsonDeserializer.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/committee/serialization/CommitteeCommandFromApiJsonDeserializer.java
@@ -100,6 +100,7 @@ public final class CommitteeCommandFromApiJsonDeserializer {
 
         final String[] users = this.fromApiJsonHelper.extractArrayNamed(CommitteeConstants.CommitteeSupportedParameters.USERS.getValue(),
                 element);
+
         baseDataValidator.reset().parameter(CommitteeConstants.CommitteeSupportedParameters.USERS.getValue()).value(users).arrayNotEmpty();
 
         throwExceptionIfValidationWarningsExist(dataValidationErrors);

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/committee/service/CommitteeConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/committee/service/CommitteeConstants.java
@@ -33,7 +33,13 @@ public final class CommitteeConstants {
 
     public enum CommitteeSupportedParameters {
 
-        CODE_VALUE_ID("id"), NAME("name"), USERS("users");
+        CODE_VALUE_ID("id"),
+        NAME("name"),
+        USERS("users"),
+        ABOVE_EXCEPTION_LIMIT("aboveExceptionLimits"),
+        BELOW_EXCEPTION_LIMIT("belowExceptionLimits"),
+        CONDITION("condition"),
+        LIMIT("limit");
 
         private final String value;
 

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/committee/service/CommitteeReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/committee/service/CommitteeReadPlatformServiceImpl.java
@@ -24,6 +24,8 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
+
 import org.apache.fineract.infrastructure.codes.data.CodeValueData;
 import org.apache.fineract.infrastructure.codes.service.CodeValueReadPlatformService;
 import org.apache.fineract.infrastructure.core.service.Page;
@@ -34,6 +36,8 @@ import org.apache.fineract.infrastructure.security.service.PlatformSecurityConte
 import org.apache.fineract.infrastructure.security.utils.ColumnValidator;
 import org.apache.fineract.organisation.committee.data.CommitteeData;
 import org.apache.fineract.organisation.committee.data.CommitteeUserData;
+import org.apache.fineract.organisation.committee.domain.CommitteeApprovalLimits;
+import org.apache.fineract.organisation.committee.domain.CommitteeApprovalLimitsRepositoryWrapper;
 import org.apache.fineract.organisation.committee.domain.CommitteeRepository;
 import org.apache.fineract.organisation.committee.exception.CommitteeNotFoundException;
 import org.apache.fineract.useradministration.data.AppUserData;
@@ -54,13 +58,15 @@ public class CommitteeReadPlatformServiceImpl implements CommitteeReadPlatformSe
     private final AppUserReadPlatformService appUserReadPlatformService;
     private final CodeValueReadPlatformService codeValueReadPlatformService;
     private final CommitteeRepository committeeRepository;
+    private final CommitteeApprovalLimitsRepositoryWrapper approvalLimitsRepositoryWrapper;
     private final PaginationHelper paginationHelper;
 
     @Autowired
     public CommitteeReadPlatformServiceImpl(final PlatformSecurityContext context, final JdbcTemplate jdbcTemplate,
             final ColumnValidator columnValidator, final DatabaseSpecificSQLGenerator sqlGenerator,
             final AppUserReadPlatformService appUserReadPlatformService, final CodeValueReadPlatformService codeValueReadPlatformService,
-            final CommitteeRepository committeeRepository, final PaginationHelper paginationHelper) {
+            final CommitteeRepository committeeRepository, final PaginationHelper paginationHelper,
+            final CommitteeApprovalLimitsRepositoryWrapper approvalLimitsRepositoryWrapper) {
         this.context = context;
         this.columnValidator = columnValidator;
         this.jdbcTemplate = jdbcTemplate;
@@ -69,6 +75,7 @@ public class CommitteeReadPlatformServiceImpl implements CommitteeReadPlatformSe
         this.codeValueReadPlatformService = codeValueReadPlatformService;
         this.committeeRepository = committeeRepository;
         this.paginationHelper = paginationHelper;
+        this.approvalLimitsRepositoryWrapper = approvalLimitsRepositoryWrapper;
     }
 
     @Override
@@ -88,16 +95,21 @@ public class CommitteeReadPlatformServiceImpl implements CommitteeReadPlatformSe
 
             CommitteeData committeeData = this.jdbcTemplate.queryForObject(sqlBuilder.toString(), committeeMapper,
                     new Object[] { committeeId });
+            assert committeeData != null;
 
             // get the selected users in the committee
             Collection<CommitteeUserData> selectedUsers = retrieveCommitteeUsers(committeeId);
 
+            List<CommitteeApprovalLimits> approvalLimits = this.approvalLimitsRepositoryWrapper.getApprovallimitsByCommittee(committeeId);
+            if (!approvalLimits.isEmpty()){
+                committeeData.setCommitteeApprovalLimits(approvalLimits);
+            }
             // get the available users to set in the committe
             final Collection<AppUserData> availableAppUsers = this.appUserReadPlatformService.retrieveUsersForCommittees();
             final Collection<CommitteeUserData> availableUsers = new ArrayList<>();
             assembleUserToData(availableAppUsers, availableUsers);
 
-            if (committeeData != null && selectedUsers != null) {
+            if (selectedUsers != null) {
                 committeeData.setSelectedUsers(selectedUsers);
                 committeeData.setAvailableUsers(availableUsers);
             }

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/committee/service/CommitteeWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/committee/service/CommitteeWritePlatformServiceJpaRepositoryImpl.java
@@ -18,8 +18,11 @@
  */
 package org.apache.fineract.organisation.committee.service;
 
+import java.math.BigDecimal;
 import java.util.List;
 import javax.persistence.PersistenceException;
+
+import com.google.gson.JsonArray;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.fineract.infrastructure.codes.domain.CodeValue;
@@ -31,6 +34,8 @@ import org.apache.fineract.infrastructure.core.exception.PlatformDataIntegrityEx
 import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
 import org.apache.fineract.organisation.committee.data.CommitteeData;
 import org.apache.fineract.organisation.committee.domain.Committee;
+import org.apache.fineract.organisation.committee.domain.CommitteeApprovalLimits;
+import org.apache.fineract.organisation.committee.domain.CommitteeApprovalLimitsRepositoryWrapper;
 import org.apache.fineract.organisation.committee.domain.CommitteeRepositoryWrapper;
 import org.apache.fineract.organisation.committee.serialization.CommitteeCommandFromApiJsonDeserializer;
 import org.apache.fineract.useradministration.domain.AppUser;
@@ -47,12 +52,14 @@ public class CommitteeWritePlatformServiceJpaRepositoryImpl implements Committee
     private final PlatformSecurityContext context;
     private final CommitteeCommandFromApiJsonDeserializer fromApiJsonDeserializer;
     private final CommitteeRepositoryWrapper committeeRepositoryWrapper;
+    private final CommitteeApprovalLimitsRepositoryWrapper approvalLimitsRepositoryWrapper;
     private final CodeValueRepository codeValueRepository;
     private final AppUserRepository appUserRepository;
     private final CommitteeReadPlatformService committeeReadPlatformService;
 
     public CommitteeWritePlatformServiceJpaRepositoryImpl(final PlatformSecurityContext context,
             final CommitteeCommandFromApiJsonDeserializer fromApiJsonDeserializer,
+            CommitteeApprovalLimitsRepositoryWrapper approvalLimitsRepositoryWrapper,
             final CommitteeRepositoryWrapper committeeRepositoryWrapper, final CodeValueRepository codeValueRepository,
             final AppUserRepository appUserRepository, final CommitteeReadPlatformService committeeReadPlatformService) {
         this.context = context;
@@ -61,6 +68,7 @@ public class CommitteeWritePlatformServiceJpaRepositoryImpl implements Committee
         this.codeValueRepository = codeValueRepository;
         this.appUserRepository = appUserRepository;
         this.committeeReadPlatformService = committeeReadPlatformService;
+        this.approvalLimitsRepositoryWrapper = approvalLimitsRepositoryWrapper;
     }
 
     @Transactional
@@ -93,6 +101,24 @@ public class CommitteeWritePlatformServiceJpaRepositoryImpl implements Committee
                 this.committeeRepositoryWrapper.save(committee);
             }
 
+            JsonArray aboveExceptionsLimit = command.arrayOfParameterNamed(CommitteeConstants.CommitteeSupportedParameters.ABOVE_EXCEPTION_LIMIT.getValue());
+            JsonArray belowExceptionsLimit = command.arrayOfParameterNamed(CommitteeConstants.CommitteeSupportedParameters.BELOW_EXCEPTION_LIMIT.getValue());
+
+            //for each of the exception limits, create new entries
+            for (int i = 0; i < aboveExceptionsLimit.size(); i++) {
+                BigDecimal fromAmount = aboveExceptionsLimit.get(i).getAsJsonObject().get("fromAmount").getAsBigDecimal();
+                BigDecimal toAmount = aboveExceptionsLimit.get(i).getAsJsonObject().get("toAmount").getAsBigDecimal();
+                Long limit = command.longValueOfParameterNamed(CommitteeConstants.CommitteeSupportedParameters.LIMIT.getValue());
+                CommitteeApprovalLimits approvalLimit = new CommitteeApprovalLimits(committeeId, fromAmount, toAmount, "GREATER_THAN",limit.intValue(), currentUser.getId());
+                this.approvalLimitsRepositoryWrapper.save(approvalLimit);
+            }
+            for (int i = 0; i < belowExceptionsLimit.size(); i++) {
+                BigDecimal fromAmount = belowExceptionsLimit.get(i).getAsJsonObject().get("fromAmount").getAsBigDecimal();
+                BigDecimal toAmount = belowExceptionsLimit.get(i).getAsJsonObject().get("toAmount").getAsBigDecimal();
+                Long limit = command.longValueOfParameterNamed(CommitteeConstants.CommitteeSupportedParameters.LIMIT.getValue());
+                CommitteeApprovalLimits approvalLimit = new CommitteeApprovalLimits(committeeId, fromAmount, toAmount, "LESS_THAN",limit.intValue(), currentUser.getId());
+                this.approvalLimitsRepositoryWrapper.save(approvalLimit);
+            }
             return new CommandProcessingResultBuilder() //
                     .withEntityId(committeeId) //
                     .build();
@@ -111,6 +137,7 @@ public class CommitteeWritePlatformServiceJpaRepositoryImpl implements Committee
     public CommandProcessingResult updateCommittee(Long committeeId, JsonCommand command) {
         try {
 
+            AppUser authenticatedUser = context.getAuthenticatedUserIfPresent();
             this.fromApiJsonDeserializer.validateForUpdate(command.json());
 
             CommitteeData committeeData = committeeReadPlatformService.findByCommitteeId(committeeId);
@@ -139,6 +166,28 @@ public class CommitteeWritePlatformServiceJpaRepositoryImpl implements Committee
                 this.committeeRepositoryWrapper.save(committee);
             }
 
+            List<CommitteeApprovalLimits> approvalLimitsByCommittee = this.approvalLimitsRepositoryWrapper.getApprovallimitsByCommittee(committeeId);
+            approvalLimitsByCommittee.forEach(limit -> this.approvalLimitsRepositoryWrapper.delete(limit));
+
+            JsonArray aboveExceptionsLimit = command.arrayOfParameterNamed(CommitteeConstants.CommitteeSupportedParameters.ABOVE_EXCEPTION_LIMIT.getValue());
+            JsonArray belowExceptionsLimit = command.arrayOfParameterNamed(CommitteeConstants.CommitteeSupportedParameters.BELOW_EXCEPTION_LIMIT.getValue());
+
+            //for each of the exception limits, create new entries
+            for (int i = 0; i < aboveExceptionsLimit.size(); i++) {
+                BigDecimal fromAmount = aboveExceptionsLimit.get(i).getAsJsonObject().get("fromAmount").getAsBigDecimal();
+                BigDecimal toAmount = aboveExceptionsLimit.get(i).getAsJsonObject().get("toAmount").getAsBigDecimal();
+                Long limit = command.longValueOfParameterNamed(CommitteeConstants.CommitteeSupportedParameters.LIMIT.getValue());
+                CommitteeApprovalLimits approvalLimit = new CommitteeApprovalLimits(committeeId, fromAmount, toAmount, "GREATER_THAN",limit.intValue(), authenticatedUser.getId());
+                this.approvalLimitsRepositoryWrapper.save(approvalLimit);
+            }
+            for (int i = 0; i < belowExceptionsLimit.size(); i++) {
+                BigDecimal fromAmount = belowExceptionsLimit.get(i).getAsJsonObject().get("fromAmount").getAsBigDecimal();
+                BigDecimal toAmount = belowExceptionsLimit.get(i).getAsJsonObject().get("toAmount").getAsBigDecimal();
+                Long limit = command.longValueOfParameterNamed(CommitteeConstants.CommitteeSupportedParameters.LIMIT.getValue());
+                CommitteeApprovalLimits approvalLimit = new CommitteeApprovalLimits(committeeId, fromAmount, toAmount, "LESS_THAN",limit.intValue(), authenticatedUser.getId());
+                this.approvalLimitsRepositoryWrapper.save(approvalLimit);
+            }
+
             return new CommandProcessingResultBuilder() //
                     .withEntityId(committeeId) //
                     .build();
@@ -163,6 +212,9 @@ public class CommitteeWritePlatformServiceJpaRepositoryImpl implements Committee
             }
 
             committeeRepositoryWrapper.deleteByCommittee(committeeCode);
+
+            List<CommitteeApprovalLimits> approvalLimitsByCommittee = this.approvalLimitsRepositoryWrapper.getApprovallimitsByCommittee(committeeId);
+            approvalLimitsByCommittee.forEach(limit -> this.approvalLimitsRepositoryWrapper.delete(limit));
 
             return new CommandProcessingResultBuilder() //
                     .withEntityId(committeeId) //

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/prequalification/command/PrequalificationCollectionConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/prequalification/command/PrequalificationCollectionConstants.java
@@ -32,7 +32,7 @@ public class PrequalificationCollectionConstants extends PrequalificatoinApiCons
     protected static final Set<String> EDIT_GROUP_PREQUALIFICATION_REQUEST_DATA_PARAMETERS = new HashSet<>(
             Arrays.asList(groupIdParamName, groupNameParamName, productIdParamName, portfolioIdParamName, centerIdParamName,
                     membersParamName, dateFormatParamName, localeParamName, agencyIdParamName, facilitatorParamName, "individual",
-                    prequalificationNumberParamName, prequalilficationTimespanParamName, previousPrequalificationParamName));
+                    prequalificationNumberParamName, prequalilficationTimespanParamName, previousPrequalificationParamName, commentParamName, reasonParamName));
 
     protected static final Set<String> EDIT_MEMBER_PREQUALIFICATION_REQUEST_DATA_PARAMETERS = new HashSet<>(
             Arrays.asList(memberIdParamName, memberNameParamName, memberDpiParamName, memberDobParamName, memberRequestedAmountParamName,

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/prequalification/command/PrequalificatoinApiConstants.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/prequalification/command/PrequalificatoinApiConstants.java
@@ -63,4 +63,6 @@ public class PrequalificatoinApiConstants {
     public static String principalParamName = "principal";
 
     public static String exceptionComments = "Comentario de excepción";
+    public static String commentParamName = "comment";
+    public static String reasonParamName = "reasonId";
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/prequalification/data/GroupPrequalificationData.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/prequalification/data/GroupPrequalificationData.java
@@ -27,6 +27,7 @@ import lombok.Data;
 import org.apache.fineract.infrastructure.configuration.data.GlobalConfigurationPropertyData;
 import org.apache.fineract.infrastructure.core.data.EnumOptionData;
 import org.apache.fineract.organisation.agency.data.AgencyData;
+import org.apache.fineract.organisation.prequalification.domain.PrequalificationTimeline;
 import org.apache.fineract.portfolio.group.data.CenterData;
 import org.apache.fineract.portfolio.loanproduct.data.LoanProductData;
 import org.apache.fineract.useradministration.data.AppUserData;
@@ -82,6 +83,8 @@ public class GroupPrequalificationData {
     private String assignedUserName;
     private String latestComments;
     private Long linkedGroupId;
+    private List<PrequalificationTimeline> currentTimeline;
+    private List<EnumOptionData> expectedTimeline;
 
     public GroupPrequalificationData(final Long id, final String productName, final String prequalificationNumber, final String agencyName,
             final String portforlioName, final String centerName, final String groupName, final String addedBy,
@@ -222,5 +225,13 @@ public class GroupPrequalificationData {
 
     public void updateMembers(Collection<MemberPrequalificationData> groupMembers) {
         this.groupMembers = groupMembers;
+    }
+
+    public void updateCurrentStatusTimeline(List<PrequalificationTimeline> prequalificationTimelines) {
+        this.currentTimeline = prequalificationTimelines;
+    }
+
+    public void updateExpectedStatusTimeline(List<EnumOptionData> expectedTimeline) {
+        this.expectedTimeline= expectedTimeline;
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/prequalification/data/MemberPrequalificationData.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/prequalification/data/MemberPrequalificationData.java
@@ -66,6 +66,7 @@ public class MemberPrequalificationData {
     private Integer period;
     private String collateral;
     private String destination;
+    private Long loanId;
 
 
     public MemberPrequalificationData(final Long id, final String name, final String dpi, final LocalDate dob, final String workWithPuente,
@@ -184,5 +185,9 @@ public class MemberPrequalificationData {
 
     public void setDocumentCount(Long documentCount) {
         this.documentCount = documentCount;
+    }
+
+    public void setLoanId(Long loanId) {
+        this.loanId = loanId;
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/prequalification/domain/PreQualificationsEnumerations.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/prequalification/domain/PreQualificationsEnumerations.java
@@ -34,6 +34,17 @@ public final class PreQualificationsEnumerations {
         return status(PrequalificationStatus.fromInt(statusId));
     }
 
+    public static EnumOptionData status(final String committeeCode) {
+        PrequalificationStatus statusId = switch (committeeCode) {
+            case "A" -> PrequalificationStatus.PRE_COMMITTEE_A_PENDING_APPROVAL;
+            case "B" -> PrequalificationStatus.PRE_COMMITTEE_B_PENDING_APPROVAL;
+            case "C" -> PrequalificationStatus.PRE_COMMITTEE_C_PENDING_APPROVAL;
+            case "D" -> PrequalificationStatus.PRE_COMMITTEE_D_PENDING_APPROVAL;
+            default -> PrequalificationStatus.INVALID;
+        };
+        return status(statusId);
+    }
+
     public static EnumOptionData status(final PrequalificationStatus status) {
         new EnumOptionData(PrequalificationStatus.INVALID.getValue().longValue(), PrequalificationStatus.INVALID.getCode(), "INVALID");
 

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/prequalification/domain/PrequalificationStatus.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/prequalification/domain/PrequalificationStatus.java
@@ -25,35 +25,26 @@ import org.springframework.util.StringUtils;
  */
 public enum PrequalificationStatus {
 
-    PENDING(100, "prequalification.status.pending"), REJECTED(300, "prequalification.status.rejected"), BLACKLIST_CHECKED(400,
-            "prequalification.status.blacklist.checked"), BLACKLIST_REJECTED(500,
-                    "prequalification.status.blacklist.rejected"), BURO_CHECKED(600,
-                            "prequalification.status.buro.checked"), HARD_POLICY_CHECKED(700,
-                                    "prequalification.status.hard.policy.checked"), TIME_EXPIRED(800,
-                                            "prequalification.status.expired"), COMPLETED(900,
-                                                    "prequalification.status.completed"), CONSENT_ADDED(701,
-                                                            "prequalification.status.concent.added"), AGENCY_LEAD_PENDING_APPROVAL(902,
-                                                                    "prequalification.status.pending.approval"), PREQUALIFICATION_UPDATE_REQUESTED(
-                                                                            903,
-                                                                            "prequalification.status.update.requested"), AGENCY_LEAD_PENDING_APPROVAL_WITH_EXCEPTIONS(
-                                                                                    904,
-                                                                                    "prequalification.status.agency.pending.approval.exceptions"), AGENCY_LEAD_APPROVED_WITH_EXCEPTIONS(
-                                                                                            905,
-                                                                                            "prequalification.status.agency.approved.with.exceptions"), ANALYSIS_UNIT_PENDING_APPROVAL(
-                                                                                                    1001,
-                                                                                                    "prequalification.status.analysis.pending.approval"), ANALYSIS_UNIT_PENDING_APPROVAL_WITH_EXCEPTIONS(
-                                                                                                            1002,
-                                                                                                            "prequalification.status.analysis.pending.approval.exceptions"), PRE_COMMITTEE_D_PENDING_APPROVAL(
-                                                                                                                    1003,
-                                                                                                                    "prequalification.status.pre.committee.d.pending.approval"), PRE_COMMITTEE_C_PENDING_APPROVAL(
-                                                                                                                            1004,
-                                                                                                                            "prequalification.status.pre.committee.c.pending.approval"), PRE_COMMITTEE_B_PENDING_APPROVAL(
-                                                                                                                                    1005,
-                                                                                                                                    "prequalification.status.committee.b.pending.approval"), PRE_COMMITTEE_A_PENDING_APPROVAL(
-                                                                                                                                            1006,
-                                                                                                                                            "prequalification.status.committee.a.pending.approval"), INVALID(
-                                                                                                                                                    0,
-                                                                                                                                                    "prequalification.status.invalid");
+    PENDING(100, "prequalification.status.pending"),
+    REJECTED(300, "prequalification.status.rejected"),
+    BLACKLIST_CHECKED(400, "prequalification.status.blacklist.checked"),
+    BLACKLIST_REJECTED(500, "prequalification.status.blacklist.rejected"),
+    BURO_CHECKED(600, "prequalification.status.buro.checked"),
+    HARD_POLICY_CHECKED(700, "prequalification.status.hard.policy.checked"),
+    TIME_EXPIRED(800, "prequalification.status.expired"),
+    COMPLETED(900, "prequalification.status.completed"),
+    CONSENT_ADDED(701, "prequalification.status.concent.added"),
+    AGENCY_LEAD_PENDING_APPROVAL(902, "prequalification.status.pending.approval"),
+    PREQUALIFICATION_UPDATE_REQUESTED(903, "prequalification.status.update.requested"),
+    AGENCY_LEAD_PENDING_APPROVAL_WITH_EXCEPTIONS(904, "prequalification.status.agency.pending.approval.exceptions"),
+    AGENCY_LEAD_APPROVED_WITH_EXCEPTIONS(905, "prequalification.status.agency.approved.with.exceptions"),
+    ANALYSIS_UNIT_PENDING_APPROVAL(1001, "prequalification.status.analysis.pending.approval"),
+    ANALYSIS_UNIT_PENDING_APPROVAL_WITH_EXCEPTIONS(1002, "prequalification.status.analysis.pending.approval.exceptions"),
+    PRE_COMMITTEE_D_PENDING_APPROVAL(1003, "prequalification.status.pre.committee.d.pending.approval"),
+    PRE_COMMITTEE_C_PENDING_APPROVAL(1004,"prequalification.status.pre.committee.c.pending.approval"),
+    PRE_COMMITTEE_B_PENDING_APPROVAL(1005,"prequalification.status.committee.b.pending.approval"),
+    PRE_COMMITTEE_A_PENDING_APPROVAL(1006,"prequalification.status.committee.a.pending.approval"),
+    INVALID(0,"prequalification.status.invalid");
 
     private final Integer value;
     private final String code;
@@ -64,61 +55,61 @@ public enum PrequalificationStatus {
         switch (statusValue) {
             case 100:
                 enumeration = PrequalificationStatus.PENDING;
-            break;
+                break;
             case 300:
                 enumeration = PrequalificationStatus.REJECTED;
-            break;
+                break;
             case 400:
                 enumeration = PrequalificationStatus.BLACKLIST_CHECKED;
-            break;
+                break;
             case 500:
                 enumeration = PrequalificationStatus.BLACKLIST_REJECTED;
-            break;
+                break;
             case 600:
                 enumeration = PrequalificationStatus.BURO_CHECKED;
-            break;
+                break;
             case 700:
                 enumeration = PrequalificationStatus.HARD_POLICY_CHECKED;
-            break;
+                break;
             case 701:
                 enumeration = PrequalificationStatus.CONSENT_ADDED;
-            break;
+                break;
             case 800:
                 enumeration = PrequalificationStatus.TIME_EXPIRED;
-            break;
+                break;
             case 900:
                 enumeration = PrequalificationStatus.COMPLETED;
-            break;
+                break;
             case 902:
                 enumeration = PrequalificationStatus.AGENCY_LEAD_PENDING_APPROVAL;
-            break;
+                break;
             case 903:
                 enumeration = PrequalificationStatus.PREQUALIFICATION_UPDATE_REQUESTED;
-            break;
+                break;
             case 904:
                 enumeration = PrequalificationStatus.AGENCY_LEAD_PENDING_APPROVAL_WITH_EXCEPTIONS;
-            break;
+                break;
             case 905:
                 enumeration = PrequalificationStatus.AGENCY_LEAD_APPROVED_WITH_EXCEPTIONS;
-            break;
+                break;
             case 1001:
                 enumeration = PrequalificationStatus.ANALYSIS_UNIT_PENDING_APPROVAL;
-            break;
+                break;
             case 1002:
                 enumeration = PrequalificationStatus.ANALYSIS_UNIT_PENDING_APPROVAL_WITH_EXCEPTIONS;
-            break;
+                break;
             case 1003:
                 enumeration = PrequalificationStatus.PRE_COMMITTEE_D_PENDING_APPROVAL;
-            break;
+                break;
             case 1004:
                 enumeration = PrequalificationStatus.PRE_COMMITTEE_C_PENDING_APPROVAL;
-            break;
+                break;
             case 1005:
                 enumeration = PrequalificationStatus.PRE_COMMITTEE_B_PENDING_APPROVAL;
-            break;
+                break;
             case 1006:
                 enumeration = PrequalificationStatus.PRE_COMMITTEE_A_PENDING_APPROVAL;
-            break;
+                break;
         }
         return enumeration;
     }

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/prequalification/domain/PrequalificationStatusLog.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/prequalification/domain/PrequalificationStatusLog.java
@@ -32,7 +32,7 @@ import org.apache.fineract.useradministration.domain.AppUser;
 @Entity
 @Table(name = "m_prequalification_status_log")
 @Getter
-public class PrequalificationStatusLog extends AbstractPersistableCustom {
+public class PrequalificationStatusLog extends AbstractPersistableCustom implements Comparable<PrequalificationStatusLog>{
 
     @ManyToOne
     @JoinColumn(name = "prequalification_id")
@@ -87,4 +87,10 @@ public class PrequalificationStatusLog extends AbstractPersistableCustom {
     public void updateSubStatus(final Integer subStatus) {
         this.subStatus = subStatus;
     }
+
+    @Override
+    public int compareTo(PrequalificationStatusLog entry) {
+        return this.getId().compareTo(entry.getId());
+    }
+
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/prequalification/domain/PrequalificationStatusLog.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/prequalification/domain/PrequalificationStatusLog.java
@@ -25,6 +25,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import lombok.Getter;
+import org.apache.fineract.infrastructure.codes.domain.CodeValue;
 import org.apache.fineract.infrastructure.core.domain.AbstractPersistableCustom;
 import org.apache.fineract.infrastructure.core.service.DateUtils;
 import org.apache.fineract.useradministration.domain.AppUser;
@@ -61,23 +62,29 @@ public class PrequalificationStatusLog extends AbstractPersistableCustom {
     @JoinColumn(name = "assigned_to", nullable = false)
     private AppUser assignedTo;
 
+    @ManyToOne
+    @JoinColumn(name = "reason_code_id")
+    private CodeValue reasonCode;
+
+
     protected PrequalificationStatusLog() {
         //
     }
 
     private PrequalificationStatusLog(final AppUser appUser, final Integer fromStatus, final Integer toStatus, final String comments,
-            final PrequalificationGroup group) {
+            final PrequalificationGroup group, final CodeValue reasonCode) {
         this.dateCreated = DateUtils.getLocalDateOfTenant();
         this.fromStatus = fromStatus;
         this.toStatus = toStatus;
         this.prequalificationGroup = group;
         this.comments = comments;
         this.addedBy = appUser;
+        this.reasonCode = reasonCode;
     }
 
     public static PrequalificationStatusLog fromJson(final AppUser appUser, final Integer fromStatus, final Integer toStatus,
-            final String comments, final PrequalificationGroup group) {
-        return new PrequalificationStatusLog(appUser, fromStatus, toStatus, comments, group);
+                                                     final String comments, final PrequalificationGroup group, CodeValue reasonCode) {
+        return new PrequalificationStatusLog(appUser, fromStatus, toStatus, comments, group, reasonCode);
     }
 
     public void updateAssignedTo(final AppUser assignedTo) {

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/prequalification/domain/PrequalificationTimeline.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/prequalification/domain/PrequalificationTimeline.java
@@ -1,0 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.organisation.prequalification.domain;
+
+import org.apache.fineract.infrastructure.core.data.EnumOptionData;
+
+/**
+ * Created by brian on 03/11/2025.
+ */
+public record PrequalificationTimeline(
+    EnumOptionData statusData,
+    String changedBy,
+    String changeDate,
+    String comments
+) {}

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/prequalification/service/BureauValidationWritePlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/prequalification/service/BureauValidationWritePlatformServiceImpl.java
@@ -136,7 +136,7 @@ public class BureauValidationWritePlatformServiceImpl implements BureauValidatio
         this.prequalificationGroupRepositoryWrapper.save(prequalificationGroup);
 
         PrequalificationStatusLog statusLog = PrequalificationStatusLog.fromJson(addedBy, fromStatus, prequalificationGroup.getStatus(),
-                null, prequalificationGroup);
+                null, prequalificationGroup, null);
 
         this.preQualificationStatusLogRepository.saveAndFlush(statusLog);
 

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/prequalification/service/PrequalificationChecklistWritePlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/prequalification/service/PrequalificationChecklistWritePlatformServiceImpl.java
@@ -204,7 +204,7 @@ public class PrequalificationChecklistWritePlatformServiceImpl implements Prequa
 
         } else {
             statusLog = PrequalificationStatusLog.fromJson(appUser, fromStatus, prequalificationGroup.getStatus(), null,
-                    prequalificationGroup);
+                    prequalificationGroup, null);
             prequalificationGroup.updateStatus(PrequalificationStatus.HARD_POLICY_CHECKED);
         }
         this.prequalificationGroupRepositoryWrapper.saveAndFlush(prequalificationGroup);

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/prequalification/service/PrequalificationReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/prequalification/service/PrequalificationReadPlatformServiceImpl.java
@@ -52,7 +52,6 @@ import org.apache.fineract.portfolio.client.service.ClientChargeWritePlatformSer
 import org.apache.fineract.portfolio.collateral.domain.LoanCollateral;
 import org.apache.fineract.portfolio.collateral.domain.LoanCollateralRepository;
 import org.apache.fineract.portfolio.loanaccount.data.LoanAccountData;
-import org.apache.fineract.portfolio.loanaccount.domain.Loan;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanRepaymentScheduleInstallment;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanRepositoryWrapper;
 import org.apache.fineract.portfolio.loanaccount.service.LoanReadPlatformService;
@@ -192,7 +191,7 @@ public class PrequalificationReadPlatformServiceImpl implements Prequalification
                 final EnumOptionData enumOptionData = PreQualificationsMemberEnumerations.status(status);
                 memberPrequalificationData.setStatus(enumOptionData);
 
-                LoanData loanData = getLoanDataByPrequalificationId(groupId);
+                LoanData loanData = getLoanDataByPrequalificationId(memberPrequalificationData.getLoanId());
 
                 memberPrequalificationData.setCollateral(loanData.getCollateral());
                 memberPrequalificationData.setDestination(loanData.getDestination());
@@ -845,6 +844,7 @@ public class PrequalificationReadPlatformServiceImpl implements Prequalification
             this.schema = """
                     	m.id AS id,
                     	m.name,
+                    	ml.id as loanId,
                     	m.status,
                     	m.comments as comments,
                     	m.agency_bureau_status as agencyBureauStatus,
@@ -932,8 +932,8 @@ public class PrequalificationReadPlatformServiceImpl implements Prequalification
                     		AND mcvr.prequalification_member_id = m.id ) AS redValidationCount
                     FROM
                     	m_prequalification_group_members m
-                    LEFT JOIN m_client mc ON
-                    	mc.dpi = m.dpi
+                    LEFT JOIN m_client mc ON mc.dpi = m.dpi
+                    LEFT JOIN m_loan ml ON ml.prequalification_id = m.group_id AND ml.client_id = mc.id 
                     """;
         }
 
@@ -982,6 +982,7 @@ public class PrequalificationReadPlatformServiceImpl implements Prequalification
             final Long yellowValidationCount = rs.getLong("yellowValidationCount");
             final Long clientId = rs.getLong("clientId");
             final Long documentCount = rs.getLong("documentCount");
+            final Long loanId = JdbcSupport.getLong(rs,"loanId");
             final Boolean groupPresident = rs.getBoolean("groupPresident");
             MemberPrequalificationData memberPrequalificationData = MemberPrequalificationData.instance(id, name, dpi, dob, puente,
                     requestedAmount, status, blacklistCount, totalLoanAmount, totalLoanBalance, totalGuaranteedLoanBalance, noOfCycles,
@@ -991,21 +992,21 @@ public class PrequalificationReadPlatformServiceImpl implements Prequalification
             memberPrequalificationData.setBuroData(buroData);
             memberPrequalificationData.setClientId(clientId);
             memberPrequalificationData.setDocumentCount(documentCount);
+            memberPrequalificationData.setLoanId(loanId);
             return memberPrequalificationData;
         }
     }
 
-    private LoanData getLoanDataByPrequalificationId(Long prequalificationId) {
+    private LoanData getLoanDataByPrequalificationId(Long loanId) {
 
-        final Loan loan = loanRepositoryWrapper.retrieveByPrequalificationId(prequalificationId);
-        if (loan != null) {
-            final LoanAccountData loanAccountData = loanReadPlatformService.retrieveOne(loan.getId());
+        if (loanId != null) {
+            final LoanAccountData loanAccountData = loanReadPlatformService.retrieveOne(loanId);
             BigDecimal quotaAmount = BigDecimal.ZERO;
             String colateral = "";
             final List<LoanRepaymentScheduleInstallment> loanRepaymentScheduleInstallments = this.loanRepositoryWrapper
-                    .getLoanRepaymentScheduleInstallments(loan.getId());
+                    .getLoanRepaymentScheduleInstallments(loanId);
 
-            final List<LoanCollateral> loanCollaterals = collateralRepository.findByLoanId(loan.getId());
+            final List<LoanCollateral> loanCollaterals = collateralRepository.findByLoanId(loanId);
 
             if (loanRepaymentScheduleInstallments != null && !loanRepaymentScheduleInstallments.isEmpty()) {
                 quotaAmount = loanRepaymentScheduleInstallments.stream()
@@ -1027,8 +1028,7 @@ public class PrequalificationReadPlatformServiceImpl implements Prequalification
             final String destination = loanAccountData.getLoanPurposeName();
 
             return new LoanData(quotaAmount, rate, period, colateral, destination);
-        } else {
-            return new LoanData(null,null,null,null,null);
         }
+        return new LoanData(null,null,null,null,null);
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/prequalification/service/PrequalificationReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/prequalification/service/PrequalificationReadPlatformServiceImpl.java
@@ -998,33 +998,37 @@ public class PrequalificationReadPlatformServiceImpl implements Prequalification
     private LoanData getLoanDataByPrequalificationId(Long prequalificationId) {
 
         final Loan loan = loanRepositoryWrapper.retrieveByPrequalificationId(prequalificationId);
-        final LoanAccountData loanAccountData = loanReadPlatformService.retrieveOne(loan.getId());
-        BigDecimal quotaAmount = BigDecimal.ZERO;
-        String colateral = "";
-        final List<LoanRepaymentScheduleInstallment> loanRepaymentScheduleInstallments = this.loanRepositoryWrapper
-                .getLoanRepaymentScheduleInstallments(loan.getId());
+        if (loan != null) {
+            final LoanAccountData loanAccountData = loanReadPlatformService.retrieveOne(loan.getId());
+            BigDecimal quotaAmount = BigDecimal.ZERO;
+            String colateral = "";
+            final List<LoanRepaymentScheduleInstallment> loanRepaymentScheduleInstallments = this.loanRepositoryWrapper
+                    .getLoanRepaymentScheduleInstallments(loan.getId());
 
-        final List<LoanCollateral> loanCollaterals = collateralRepository.findByLoanId(loan.getId());
+            final List<LoanCollateral> loanCollaterals = collateralRepository.findByLoanId(loan.getId());
 
-        if (loanRepaymentScheduleInstallments != null && !loanRepaymentScheduleInstallments.isEmpty()) {
-            quotaAmount = loanRepaymentScheduleInstallments.stream()
-                    .filter(item -> item.getInstallmentNumber() == 1)
-                    .map(item -> item.getTotalOutstanding(item.getLoan().getCurrency()).getAmount())
-                    .reduce(BigDecimal.ZERO, BigDecimal::add);
+            if (loanRepaymentScheduleInstallments != null && !loanRepaymentScheduleInstallments.isEmpty()) {
+                quotaAmount = loanRepaymentScheduleInstallments.stream()
+                        .filter(item -> item.getInstallmentNumber() == 1)
+                        .map(item -> item.getTotalOutstanding(item.getLoan().getCurrency()).getAmount())
+                        .reduce(BigDecimal.ZERO, BigDecimal::add);
 
-        }
-
-        if (loanCollaterals != null && !loanCollaterals.isEmpty()) {
-            for (final LoanCollateral collateral : loanCollaterals) {
-                colateral = collateral.toData().getType().getName();
-                break;
             }
+
+            if (loanCollaterals != null && !loanCollaterals.isEmpty()) {
+                for (final LoanCollateral collateral : loanCollaterals) {
+                    colateral = collateral.toData().getType().getName();
+                    break;
+                }
+            }
+
+            final BigDecimal rate = loanAccountData.getInterestRatePerPeriod();
+            final Integer period = loanAccountData.getTermFrequency();
+            final String destination = loanAccountData.getLoanPurposeName();
+
+            return new LoanData(quotaAmount, rate, period, colateral, destination);
+        } else {
+            return new LoanData(null,null,null,null,null);
         }
-
-        final BigDecimal rate = loanAccountData.getInterestRatePerPeriod();
-        final Integer period = loanAccountData.getTermFrequency();
-        final String destination = loanAccountData.getLoanPurposeName();
-
-        return new LoanData(quotaAmount, rate, period, colateral, destination);
     }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/prequalification/service/PrequalificationReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/prequalification/service/PrequalificationReadPlatformServiceImpl.java
@@ -25,7 +25,10 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -42,17 +45,25 @@ import org.apache.fineract.infrastructure.core.service.database.DatabaseSpecific
 import org.apache.fineract.infrastructure.dataqueries.service.GenericDataService;
 import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
 import org.apache.fineract.infrastructure.security.utils.ColumnValidator;
+import org.apache.fineract.organisation.committee.data.CommitteeApprovalsData;
+import org.apache.fineract.organisation.committee.mappers.RequiredCommitteeApprovalsMapper;
 import org.apache.fineract.organisation.prequalification.data.BuroData;
 import org.apache.fineract.organisation.prequalification.data.GroupPrequalificationData;
 import org.apache.fineract.organisation.prequalification.data.MemberPrequalificationData;
+import org.apache.fineract.organisation.prequalification.data.PrequalificationChecklistData;
 import org.apache.fineract.organisation.prequalification.domain.BuroCheckClassification;
+import org.apache.fineract.organisation.prequalification.domain.PreQualificationStatusLogRepository;
 import org.apache.fineract.organisation.prequalification.domain.PreQualificationsEnumerations;
 import org.apache.fineract.organisation.prequalification.domain.PreQualificationsMemberEnumerations;
+import org.apache.fineract.organisation.prequalification.domain.PrequalificationGroup;
 import org.apache.fineract.organisation.prequalification.domain.PrequalificationMemberIndication;
 import org.apache.fineract.organisation.prequalification.domain.PrequalificationStatus;
+import org.apache.fineract.organisation.prequalification.domain.PrequalificationStatusLog;
+import org.apache.fineract.organisation.prequalification.domain.PrequalificationTimeline;
 import org.apache.fineract.organisation.prequalification.domain.PrequalificationType;
 import org.apache.fineract.organisation.prequalification.domain.SubStatusEnumerations;
 import org.apache.fineract.portfolio.client.service.ClientChargeWritePlatformServiceJpaRepositoryImpl;
+import org.apache.fineract.portfolio.loanproduct.domain.LoanProduct;
 import org.apache.fineract.useradministration.domain.AppUser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -66,7 +77,7 @@ import org.springframework.stereotype.Service;
 public class PrequalificationReadPlatformServiceImpl implements PrequalificationReadPlatformService {
 
     private static final Logger LOG = LoggerFactory.getLogger(ClientChargeWritePlatformServiceJpaRepositoryImpl.class);
-
+    private final PreQualificationStatusLogRepository preQualificationLogRepository;
     private final PlatformSecurityContext context;
     private final CodeValueReadPlatformService codeValueReadPlatformService;
     private final JdbcTemplate jdbcTemplate;
@@ -76,14 +87,17 @@ public class PrequalificationReadPlatformServiceImpl implements Prequalification
     private final PrequalificationsGroupMappingsMapper mappingsMapper = new PrequalificationsGroupMappingsMapper();
     private final PrequalificationIndividualMappingsMapper prequalificationIndividualMappingsMapper = new PrequalificationIndividualMappingsMapper();
     private final PrequalificationsMemberMapper prequalificationsMemberMapper = new PrequalificationsMemberMapper();
+    private final RequiredCommitteeApprovalsMapper committeeApprovalsMapper = new RequiredCommitteeApprovalsMapper();
     private final DatabaseSpecificSQLGenerator sqlGenerator;
     private final GenericDataService genericDataService;
+    private final PrequalificationChecklistReadPlatformService prequalificationChecklistReadPlatformService;
 
     @Autowired
     public PrequalificationReadPlatformServiceImpl(final PlatformSecurityContext context, final PaginationHelper paginationHelper,
             final DatabaseSpecificSQLGenerator sqlGenerator, final ColumnValidator columnValidator,
             final CodeValueReadPlatformService codeValueReadPlatformService, final JdbcTemplate jdbcTemplate,
-            GenericDataService genericDataService) {
+            GenericDataService genericDataService,final PreQualificationStatusLogRepository preQualificationLogRepository,
+            PrequalificationChecklistReadPlatformService prequalificationChecklistReadPlatformService) {
         this.context = context;
         this.codeValueReadPlatformService = codeValueReadPlatformService;
         this.jdbcTemplate = jdbcTemplate;
@@ -91,6 +105,8 @@ public class PrequalificationReadPlatformServiceImpl implements Prequalification
         this.sqlGenerator = sqlGenerator;
         this.columnValidator = columnValidator;
         this.genericDataService = genericDataService;
+        this.preQualificationLogRepository = preQualificationLogRepository;
+        this.prequalificationChecklistReadPlatformService = prequalificationChecklistReadPlatformService;
     }
 
     @Override
@@ -151,13 +167,26 @@ public class PrequalificationReadPlatformServiceImpl implements Prequalification
 
         final String sql = "select " + this.prequalificationsGroupMapper.schema() + " WHERE g.id = ? ";
         final GroupPrequalificationData clientData = this.jdbcTemplate.queryForObject(sql, this.prequalificationsGroupMapper,
-                new Object[] { groupId });
+                new Object[]{groupId});
 
+        List<PrequalificationStatusLog> statusLogList = this.preQualificationLogRepository.groupStatusLogs(groupId);
+        PrequalificationGroup prequalificationGroup = null;
+        if (!statusLogList.isEmpty()) {
+            prequalificationGroup = statusLogList.get(0).getPrequalificationGroup();
+        }
+        LoanProduct loanProduct = prequalificationGroup.getLoanProduct();
+        List<PrequalificationTimeline> prequalificationTimelines = resolveCurrentStatusTimeline(prequalificationGroup, statusLogList);
+        clientData.updateCurrentStatusTimeline(prequalificationTimelines);
+        List<EnumOptionData> expectedTimeline = resolveFutureStatusTimeline();
+        if (loanProduct.getRequireCommitteeApproval()){
+            expectedTimeline =  resolveCommitteeApprovalsTimeline(clientData, prequalificationGroup, expectedTimeline);
+        }
+        clientData.updateExpectedStatusTimeline(expectedTimeline);
         if (clientData != null) {
             final String membersql = "select " + this.prequalificationsMemberMapper.schema() + " WHERE m.group_id = ? ";
 
             List<MemberPrequalificationData> members = this.jdbcTemplate.query(membersql, this.prequalificationsMemberMapper,
-                    new Object[] { groupId, groupId });
+                    new Object[]{groupId, groupId});
 
             for (MemberPrequalificationData memberPrequalificationData : members) {
                 Integer status = PrequalificationMemberIndication.NONE.getValue();
@@ -178,6 +207,66 @@ public class PrequalificationReadPlatformServiceImpl implements Prequalification
             clientData.updateMembers(members);
         }
         return clientData;
+    }
+
+    private List<EnumOptionData> resolveCommitteeApprovalsTimeline(GroupPrequalificationData clientData, PrequalificationGroup prequalificationGroup, List<EnumOptionData> expectedTimeline) {
+        BigDecimal totalApprovedAmount = clientData.getTotalApprovedAmount();
+        if (prequalificationGroup.getStatus()>=PrequalificationStatus.HARD_POLICY_CHECKED.getValue() &&
+                !prequalificationGroup.getStatus().equals(PrequalificationStatus.TIME_EXPIRED.getValue())){
+            PrequalificationChecklistData prequalificationChecklistData = this.prequalificationChecklistReadPlatformService
+                    .retrieveHardPolicyValidationResults(prequalificationGroup.getId());
+            List<List<String>> rows = prequalificationChecklistData.getMembers().getRows();
+            AtomicReference<Integer> redCountRef = new AtomicReference<>(0);
+            for (List<String> innerList : rows) {
+                innerList.forEach(item -> {
+                    if ("RED".equalsIgnoreCase(item) || "ORANGE".equalsIgnoreCase(item) || "YELLOW".equalsIgnoreCase(item)) {
+                        redCountRef.getAndSet(redCountRef.get() + 1);
+                    }
+                });
+            }
+            Integer errorWarningsCount = redCountRef.get();
+            final String membersql = "select " + this.committeeApprovalsMapper.schema() + " " +
+                    "WHERE ? BETWEEN c.from_amount AND c.to_amount " +
+                    "AND ( " +
+                    "    (? > c.limit AND c.condition = 'GREATER_THAN') " +
+                    "    OR (? <= c.limit AND c.condition = 'LESS_THAN') );";
+
+            List<CommitteeApprovalsData> members = this.jdbcTemplate.query(membersql, this.committeeApprovalsMapper,
+                    new Object[]{totalApprovedAmount, errorWarningsCount, errorWarningsCount});
+            if (!members.isEmpty()){
+                members.forEach(committeeApprovalsData -> {
+                    expectedTimeline.add(committeeApprovalsData.getApprovalData());
+                });
+            }
+        }
+        return expectedTimeline;
+    }
+
+    private List<EnumOptionData> resolveFutureStatusTimeline(){
+        List<EnumOptionData> statusTimeline = new ArrayList<>();
+        statusTimeline.add(PreQualificationsEnumerations.status(PrequalificationStatus.PENDING));
+        statusTimeline.add(PreQualificationsEnumerations.status(PrequalificationStatus.BLACKLIST_CHECKED));
+        statusTimeline.add(PreQualificationsEnumerations.status(PrequalificationStatus.CONSENT_ADDED));
+        statusTimeline.add(PreQualificationsEnumerations.status(PrequalificationStatus.BURO_CHECKED));
+        statusTimeline.add(PreQualificationsEnumerations.status(PrequalificationStatus.HARD_POLICY_CHECKED));
+        statusTimeline.add(PreQualificationsEnumerations.status(PrequalificationStatus.AGENCY_LEAD_PENDING_APPROVAL));
+        statusTimeline.add(PreQualificationsEnumerations.status(PrequalificationStatus.ANALYSIS_UNIT_PENDING_APPROVAL));
+        return statusTimeline;
+    }
+
+    private List<PrequalificationTimeline> resolveCurrentStatusTimeline(PrequalificationGroup prequalificationGroup, List<PrequalificationStatusLog> statusLogList){
+        List<PrequalificationTimeline> statusTimeline = new ArrayList<>();
+        statusTimeline.add(new PrequalificationTimeline(PreQualificationsEnumerations.status(PrequalificationStatus.PENDING),
+                prequalificationGroup.getAddedBy().getDisplayName(),
+                prequalificationGroup.getCreatedAt().toString(),
+                "Prequalification created"));
+        Collections.sort(statusLogList);
+        for (PrequalificationStatusLog status: statusLogList){
+            EnumOptionData statusData = PreQualificationsEnumerations.status(status.getToStatus());
+            PrequalificationTimeline prequalificationTimeline = new PrequalificationTimeline(statusData, status.getAddedBy().getDisplayName(), status.getDateCreated().toString(), status.getComments());
+            statusTimeline.add(prequalificationTimeline);
+        }
+        return statusTimeline;
     }
 
     @Override

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/prequalification/service/PrequalificationWritePlatformService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/prequalification/service/PrequalificationWritePlatformService.java
@@ -47,4 +47,6 @@ public interface PrequalificationWritePlatformService {
     void uploadMemberDocs(Long memberId);
 
     void addExceptionCommentsToPrequalification(Long blacklistId, String comment);
+
+    CommandProcessingResult returnToApproval(Long entityId, JsonCommand command);
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/prequalification/service/PrequalificationWritePlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/prequalification/service/PrequalificationWritePlatformServiceImpl.java
@@ -28,6 +28,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.fineract.commands.domain.CommandSource;
 import org.apache.fineract.commands.domain.CommandSourceRepository;
 import org.apache.fineract.infrastructure.codes.data.CodeValueData;
+import org.apache.fineract.infrastructure.codes.domain.CodeValue;
+import org.apache.fineract.infrastructure.codes.domain.CodeValueRepository;
 import org.apache.fineract.infrastructure.codes.service.CodeValueReadPlatformService;
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
@@ -155,6 +157,7 @@ public class PrequalificationWritePlatformServiceImpl implements Prequalificatio
     private final PrequalificationChecklistWritePlatformService prequalificationChecklistWritePlatformService;
     private final LoanReadPlatformService loanReadPlatformService;
     private final CommandSourceRepository commandSourceRepository;
+    private final CodeValueRepository codeValueRepository;
 
     @Autowired
     public PrequalificationWritePlatformServiceImpl(final PlatformSecurityContext context,
@@ -175,7 +178,7 @@ public class PrequalificationWritePlatformServiceImpl implements Prequalificatio
             final LoanApplicationWritePlatformService loanApplicationWritePlatformService,
             final PrequalificationChecklistWritePlatformService prequalificationChecklistWritePlatformService,
             final LoanReadPlatformService loanReadPlatformService, final GroupLoanAdditionalsRepository groupLoanAdditionalsRepository,
-            final LoanRepositoryWrapper loanRepositoryWrapper, final CommandSourceRepository commandSourceRepository) {
+            final LoanRepositoryWrapper loanRepositoryWrapper, final CommandSourceRepository commandSourceRepository, final CodeValueRepository codeValueRepository) {
         this.context = context;
         this.dataValidator = dataValidator;
         this.loanProductRepository = loanProductRepository;
@@ -203,6 +206,7 @@ public class PrequalificationWritePlatformServiceImpl implements Prequalificatio
         this.prequalificationChecklistWritePlatformService = prequalificationChecklistWritePlatformService;
         this.loanReadPlatformService = loanReadPlatformService;
         this.commandSourceRepository = commandSourceRepository;
+        this.codeValueRepository = codeValueRepository;
     }
 
     @Transactional
@@ -277,7 +281,7 @@ public class PrequalificationWritePlatformServiceImpl implements Prequalificatio
         this.prequalificationGroupRepositoryWrapper.saveAndFlush(prequalificationGroup);
 
         PrequalificationStatusLog statusLog = PrequalificationStatusLog.fromJson(addedBy, PrequalificationStatus.PENDING.getValue(),
-                prequalificationGroup.getStatus(), null, prequalificationGroup);
+                prequalificationGroup.getStatus(), null, prequalificationGroup, null);
 
         this.preQualificationLogRepository.saveAndFlush(statusLog);
 
@@ -443,7 +447,7 @@ public class PrequalificationWritePlatformServiceImpl implements Prequalificatio
         this.prequalificationGroupRepositoryWrapper.saveAndFlush(prequalificationGroup);
         AppUser addedBy = this.context.getAuthenticatedUserIfPresent();
         PrequalificationStatusLog statusLog = PrequalificationStatusLog.fromJson(addedBy, fromStatus, prequalificationGroup.getStatus(),
-                comment, prequalificationGroup);
+                comment, prequalificationGroup, null);
         this.preQualificationLogRepository.saveAndFlush(statusLog);
         return groupId;
     }
@@ -829,7 +833,7 @@ public class PrequalificationWritePlatformServiceImpl implements Prequalificatio
         this.prequalificationGroupRepositoryWrapper.save(prequalificationGroup);
 
         PrequalificationStatusLog statusLog = PrequalificationStatusLog.fromJson(addedBy, fromStatus, prequalificationGroup.getStatus(),
-                comments, prequalificationGroup);
+                comments, prequalificationGroup, null);
 
         this.preQualificationLogRepository.saveAndFlush(statusLog);
         return new CommandProcessingResultBuilder().withCommandId(command.commandId()).withEntityId(prequalificationGroup.getId()).build();
@@ -860,7 +864,7 @@ public class PrequalificationWritePlatformServiceImpl implements Prequalificatio
 
         String comments = command.stringValueOfParameterNamed("comments");
         PrequalificationStatusLog statusLog = PrequalificationStatusLog.fromJson(appUser, fromStatus, prequalificationGroup.getStatus(),
-                comments, prequalificationGroup);
+                comments, prequalificationGroup, null);
 
         this.preQualificationLogRepository.saveAndFlush(statusLog);
 
@@ -895,8 +899,26 @@ public class PrequalificationWritePlatformServiceImpl implements Prequalificatio
 
         String comments = command.stringValueOfParameterNamed("comments");
         PrequalificationStatusLog statusLog = PrequalificationStatusLog.fromJson(appUser, fromStatus, prequalificationGroup.getStatus(),
-                comments, prequalificationGroup);
+                comments, prequalificationGroup, null);
 
+        this.preQualificationLogRepository.saveAndFlush(statusLog);
+
+        return new CommandProcessingResultBuilder().withCommandId(command.commandId()).withEntityId(prequalificationGroup.getId()).build();
+    }
+
+    @Override
+    public CommandProcessingResult returnToApproval(Long entityId, JsonCommand command) {
+        final PrequalificationGroup prequalificationGroup = this.prequalificationGroupRepositoryWrapper
+                .findOneWithNotFoundDetection(entityId);
+
+        AppUser appUser = this.context.authenticatedUser();
+        Integer fromStatus = prequalificationGroup.getStatus();
+
+        prequalificationGroup.updateStatus(PrequalificationStatus.PENDING);
+
+        String comments = command.stringValueOfParameterNamed("comments");
+        PrequalificationStatusLog statusLog = PrequalificationStatusLog.fromJson(appUser, fromStatus, prequalificationGroup.getStatus(),
+                comments, prequalificationGroup, null);
         this.preQualificationLogRepository.saveAndFlush(statusLog);
 
         return new CommandProcessingResultBuilder().withCommandId(command.commandId()).withEntityId(prequalificationGroup.getId()).build();
@@ -907,6 +929,7 @@ public class PrequalificationWritePlatformServiceImpl implements Prequalificatio
     public CommandProcessingResult processAnalysisRequest(Long entityId, JsonCommand command) {
         String comments = command.stringValueOfParameterNamed("comments");
         String action = command.stringValueOfParameterNamed("action");
+        final Long reasonCode = command.longValueOfParameterNamed("reasonId");
         AppUser addedBy = this.context.authenticatedUser();
         final PrequalificationGroup prequalificationGroup = this.prequalificationGroupRepositoryWrapper
                 .findOneWithNotFoundDetection(entityId);
@@ -957,8 +980,17 @@ public class PrequalificationWritePlatformServiceImpl implements Prequalificatio
         prequalificationGroup.updateStatus(prequalificationStatus);
         prequalificationGroup.updateComments(comments);
 
+        CodeValue code = null;
+        if (reasonCode != null) {
+            Optional<CodeValue> codeValue;
+            codeValue = this.codeValueRepository.findById(reasonCode);
+            if (codeValue.isPresent()) {
+                code = codeValue.get();
+            }
+        }
+
         PrequalificationStatusLog newStatusLog = PrequalificationStatusLog.fromJson(addedBy, fromStatus, prequalificationGroup.getStatus(),
-                comments, prequalificationGroup);
+                comments, prequalificationGroup, code);
         this.approveOrRejectLoanApplications(prequalificationGroup, prequalificationStatus, memberPrequalificationDataList);
         this.preQualificationLogRepository.saveAndFlush(newStatusLog);
 
@@ -1201,6 +1233,8 @@ public class PrequalificationWritePlatformServiceImpl implements Prequalificatio
             status = PrequalificationStatus.REJECTED;
         } else if (action.equalsIgnoreCase("approveanalysis")) {
             status = PrequalificationStatus.COMPLETED;
+        } else if (action.equalsIgnoreCase("pending")) {
+            status = PrequalificationStatus.PENDING;
         }
         return status;
     }
@@ -1293,7 +1327,7 @@ public class PrequalificationWritePlatformServiceImpl implements Prequalificatio
         this.prequalificationGroupRepositoryWrapper.saveAndFlush(prequalificationGroup);
         AppUser addedBy = this.context.getAuthenticatedUserIfPresent();
         PrequalificationStatusLog statusLog = PrequalificationStatusLog.fromJson(addedBy, prequalificationGroup.getStatus(), prequalificationGroup.getStatus(),
-                comment, prequalificationGroup);
+                comment, prequalificationGroup, null);
         this.preQualificationLogRepository.saveAndFlush(statusLog);
     }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/useradministration/service/AppUserWritePlatformService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/useradministration/service/AppUserWritePlatformService.java
@@ -21,6 +21,7 @@ package org.apache.fineract.useradministration.service;
 import javax.servlet.http.HttpServletRequest;
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.apache.fineract.infrastructure.security.service.PlatformPasswordEncoder;
 import org.apache.fineract.useradministration.domain.AppUser;
 
 public interface AppUserWritePlatformService {
@@ -32,4 +33,10 @@ public interface AppUserWritePlatformService {
     CommandProcessingResult deleteUser(Long userId);
 
     void logUserAuthenticationDetails(AppUser appUser, HttpServletRequest servletRequest, String action, String result, String username);
+
+    AppUser selfResetUserPassword(Long userId, String apiRequestBodyAsJson, PlatformPasswordEncoder platformPasswordEncoder);
+
+    AppUser completePasswordReset(String username, String otp, Boolean logoutDevices, PlatformPasswordEncoder platformPasswordEncoder);
+
+    AppUser requestPasswordReset(String username);
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/useradministration/service/AppUserWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/useradministration/service/AppUserWritePlatformServiceJpaRepositoryImpl.java
@@ -23,25 +23,49 @@ import com.google.common.collect.Iterables;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import javax.persistence.PersistenceException;
 import javax.servlet.http.HttpServletRequest;
+
+import com.google.gson.JsonObject;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.fineract.commands.service.CommandWrapperBuilder;
 import org.apache.fineract.infrastructure.core.api.JsonCommand;
 import org.apache.fineract.infrastructure.core.data.ApiParameterError;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
 import org.apache.fineract.infrastructure.core.data.CommandProcessingResultBuilder;
+import org.apache.fineract.infrastructure.core.domain.EmailDetail;
 import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
 import org.apache.fineract.infrastructure.core.exception.PlatformDataIntegrityException;
+import org.apache.fineract.infrastructure.core.serialization.FromJsonHelper;
 import org.apache.fineract.infrastructure.core.service.PlatformEmailSendException;
+import org.apache.fineract.infrastructure.core.service.PlatformEmailService;
+import org.apache.fineract.infrastructure.security.constants.TwoFactorConstants;
+import org.apache.fineract.infrastructure.security.data.OTPDeliveryMethod;
+import org.apache.fineract.infrastructure.security.data.OTPRequest;
+import org.apache.fineract.infrastructure.security.domain.BasicPasswordEncodablePlatformUser;
+import org.apache.fineract.infrastructure.security.domain.OTPRequestRepository;
+import org.apache.fineract.infrastructure.security.domain.PlatformUser;
+import org.apache.fineract.infrastructure.security.domain.TFAccessToken;
+import org.apache.fineract.infrastructure.security.domain.TFAccessTokenRepository;
+import org.apache.fineract.infrastructure.security.exception.OTPDeliveryMethodInvalidException;
+import org.apache.fineract.infrastructure.security.exception.OTPTokenInvalidException;
+import org.apache.fineract.infrastructure.security.service.AccessTokenGenerationService;
 import org.apache.fineract.infrastructure.security.service.PlatformPasswordEncoder;
 import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
+import org.apache.fineract.infrastructure.security.service.RandomOTPGenerator;
+import org.apache.fineract.infrastructure.security.service.TwoFactorConfigurationService;
+import org.apache.fineract.infrastructure.sms.domain.SmsMessage;
+import org.apache.fineract.infrastructure.sms.domain.SmsMessageRepository;
+import org.apache.fineract.infrastructure.sms.scheduler.SmsMessageScheduledJobService;
 import org.apache.fineract.organisation.office.domain.Office;
 import org.apache.fineract.organisation.office.domain.OfficeRepositoryWrapper;
 import org.apache.fineract.organisation.staff.domain.Staff;
@@ -50,6 +74,7 @@ import org.apache.fineract.portfolio.client.domain.Client;
 import org.apache.fineract.portfolio.client.domain.ClientRepositoryWrapper;
 import org.apache.fineract.useradministration.api.AppUserApiConstant;
 import org.apache.fineract.useradministration.domain.AppUser;
+import org.apache.fineract.useradministration.domain.AppUserDevicesRepository;
 import org.apache.fineract.useradministration.domain.AppUserPreviousPassword;
 import org.apache.fineract.useradministration.domain.AppUserPreviousPasswordRepository;
 import org.apache.fineract.useradministration.domain.AppUserRepository;
@@ -67,6 +92,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.orm.jpa.JpaSystemException;
 import org.springframework.security.authentication.AuthenticationServiceException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.ObjectUtils;
@@ -87,6 +113,15 @@ public class AppUserWritePlatformServiceJpaRepositoryImpl implements AppUserWrit
     private final StaffRepositoryWrapper staffRepositoryWrapper;
     private final ClientRepositoryWrapper clientRepositoryWrapper;
     private final JdbcTemplate jdbcTemplate;
+    private final FromJsonHelper fromApiJsonHelper;
+    private final OTPRequestRepository otpRequestRepository;
+    private final AccessTokenGenerationService accessTokenGenerationService;
+    private final PlatformEmailService emailService;
+    private final AppUserDevicesRepository appUserDevicesRepository;
+    private final TFAccessTokenRepository tfAccessTokenRepository;
+    private final TwoFactorConfigurationService configurationService;
+    private final SmsMessageRepository smsMessageRepository;
+    private final SmsMessageScheduledJobService smsMessageScheduledJobService;
 
     @Override
     @Transactional
@@ -311,6 +346,147 @@ public class AppUserWritePlatformServiceJpaRepositoryImpl implements AppUserWrit
                 + "values(?, ?,?,?,?,?,?,current_timestamp ,1) ", action, "AUTHENTICATION", appUser.getOffice().getId(), "/authenticate",
                 "{ipAddress:\"" + clientIp + "\", result: \"" + result + "\"}", userId, userId);
     }
+
+    @Override
+    public AppUser selfResetUserPassword(Long userId, String requestData, PlatformPasswordEncoder platformPasswordEncoder) {
+        Optional<AppUser> appUserOptional = this.appUserRepository.findById(userId);
+        if (appUserOptional.isEmpty()) throw new UserNotFoundException(userId);
+        AppUser appUser = appUserOptional.get();
+        JsonElement jsonElement = this.fromApiJsonHelper.parse(requestData);
+        JsonObject asJsonObject = jsonElement.getAsJsonObject();
+        if (jsonElement.isJsonObject()) {
+            String password = this.fromApiJsonHelper.extractStringNamed("password", jsonElement);
+            String passwordRepeat = this.fromApiJsonHelper.extractStringNamed("repeatPassword", jsonElement);
+            final String jsonCommand = asJsonObject.toString();
+            final JsonCommand command = JsonCommand.from(jsonCommand, asJsonObject, this.fromApiJsonHelper, null, userId, null, null, null,
+                    null, null, null, null, null, null, null);
+            final String passwordEncodedValue = command.passwordValueOfParameterNamed("password", platformPasswordEncoder, appUser.getId());
+            appUser.updatePassword(passwordEncodedValue);
+            appUser.updateResetPassword(false);
+            this.appUserRepository.save(appUser);
+        }
+        return appUser;
+    }
+
+    @Override
+    public AppUser completePasswordReset(String username, String otp, Boolean logoutDevices,
+                                         PlatformPasswordEncoder platformPasswordEncoder) {
+        AppUser appUser = this.appUserRepository.findAppUserByName(username);
+        if (appUser == null) {
+            throw new UsernameNotFoundException(username);
+        }
+        OTPRequest otpRequest = otpRequestRepository.getOTPRequestForUser(appUser);
+        if (otpRequest == null || !otpRequest.isValid() || !otpRequest.getToken().equalsIgnoreCase(otp)) {
+            throw new OTPTokenInvalidException();
+        }
+        otpRequestRepository.deleteOTPRequestForUser(appUser);
+        String newPassword = this.accessTokenGenerationService.generateRandomToken().substring(0, 8);
+
+        final PlatformUser dummyPlatformUser = new BasicPasswordEncodablePlatformUser(appUser.getId(), "", newPassword);
+        String encodedPass = platformPasswordEncoder.encode(dummyPlatformUser);
+
+        this.jdbcTemplate.update("UPDATE m_appuser SET reset_password = ?, password=?, nonlocked=true WHERE id = ?", true, encodedPass,
+                appUser.getId());
+
+        final String emailSubject = "Password Reset Successful";
+        final String emailBody = "Your password has been reset. Your new password is: " + newPassword;
+        final EmailDetail emailData = new EmailDetail(emailSubject, emailBody, appUser.getEmail(),
+                appUser.getFirstname() + " " + appUser.getLastname());
+        emailService.sendDefinedEmail(emailData);
+
+        if (logoutDevices) {
+            this.appUserDevicesRepository.findByUser(appUser).forEach(device -> {
+                this.appUserDevicesRepository.delete(device);
+            });
+        }
+        List<TFAccessToken> tfAccessTokens = this.tfAccessTokenRepository.findByUser(appUser);
+        tfAccessTokens.forEach(token -> {
+            this.tfAccessTokenRepository.delete(token);
+        });
+
+        return appUser;
+    }
+
+    @Override
+    public AppUser requestPasswordReset(String username) {
+        AppUser appUserByName = this.appUserRepository.findAppUserByName(username);
+        if (appUserByName == null) {
+            throw new UsernameNotFoundException(username);
+        }
+        OTPRequest request = createNewOTPToken(appUserByName, TwoFactorConstants.EMAIL_DELIVERY_METHOD_NAME, false);
+
+        return appUserByName;
+    }
+
+    public OTPRequest createNewOTPToken(final AppUser user, final String deliveryMethodName, final boolean extendedAccessToken) {
+        if (TwoFactorConstants.SMS_DELIVERY_METHOD_NAME.equalsIgnoreCase(deliveryMethodName)) {
+            OTPDeliveryMethod smsDelivery = getSMSDeliveryMethodForUser(user);
+            if (smsDelivery == null) {
+                throw new OTPDeliveryMethodInvalidException();
+            }
+            final OTPRequest request = generateNewToken(smsDelivery, extendedAccessToken);
+            final String smsText = configurationService.getFormattedSmsTextFor(user, request);
+            SmsMessage smsMessage = SmsMessage.pendingSms(null, null, null, user.getStaff(), smsText, user.getStaff().mobileNo(), null,
+                    false);
+            this.smsMessageRepository.save(smsMessage);
+            smsMessageScheduledJobService.sendTriggeredMessage(Collections.singleton(smsMessage), configurationService.getSMSProviderId());
+            otpRequestRepository.addOTPRequest(user, request);
+            return request;
+        } else if (TwoFactorConstants.EMAIL_DELIVERY_METHOD_NAME.equalsIgnoreCase(deliveryMethodName)) {
+            OTPDeliveryMethod emailDelivery = getEmailDeliveryMethodForUser(user);
+            if (emailDelivery == null) {
+                throw new OTPDeliveryMethodInvalidException();
+            }
+            final OTPRequest request = generateNewToken(emailDelivery, extendedAccessToken);
+            final String emailSubject = configurationService.getFormattedEmailSubjectFor(user, request);
+            final String emailBody = configurationService.getFormattedEmailBodyFor(user, request);
+            final EmailDetail emailData = new EmailDetail(emailSubject, emailBody, user.getEmail(),
+                    user.getFirstname() + " " + user.getLastname());
+            emailService.sendDefinedEmail(emailData);
+            otpRequestRepository.addOTPRequest(user, request);
+            return request;
+        }
+
+        throw new OTPDeliveryMethodInvalidException();
+    }
+
+    private OTPDeliveryMethod getSMSDeliveryMethodForUser(final AppUser user) {
+        if (!configurationService.isSMSEnabled()) {
+            return null;
+        }
+
+        if (configurationService.getSMSProviderId() == null) {
+            return null;
+        }
+
+        if (user.getStaff() == null) {
+            return null;
+        }
+        String mobileNo = user.getStaff().mobileNo();
+        if (StringUtils.isBlank(mobileNo)) {
+            return null;
+        }
+
+        int accessTokenExtendedLiveTime = (this.configurationService.getAccessTokenExtendedLiveTime() / 86400);
+        return new OTPDeliveryMethod(TwoFactorConstants.SMS_DELIVERY_METHOD_NAME, mobileNo, Integer.toString(accessTokenExtendedLiveTime));
+    }
+
+    private OTPDeliveryMethod getEmailDeliveryMethodForUser(final AppUser user) {
+        if (!configurationService.isEmailEnabled()) {
+            return null;
+        }
+        int accessTokenExtendedLiveTime = (this.configurationService.getAccessTokenExtendedLiveTime() / 86400);
+        return new OTPDeliveryMethod(TwoFactorConstants.EMAIL_DELIVERY_METHOD_NAME, user.getEmail(),
+                Integer.toString(accessTokenExtendedLiveTime));
+    }
+
+    private OTPRequest generateNewToken(final OTPDeliveryMethod deliveryMethod, final boolean extendedAccessToken) {
+        int tokenLiveTime = configurationService.getOTPTokenLiveTime();
+        int otpLength = configurationService.getOTPTokenLength();
+        String token = new RandomOTPGenerator(otpLength).generate();
+        return OTPRequest.create(token, tokenLiveTime, extendedAccessToken, deliveryMethod);
+    }
+
 
     /*
      * Return an exception to throw, no matter what the data integrity issue is.

--- a/fineract-provider/src/main/java/org/apache/fineract/useradministration/service/AppUserWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/useradministration/service/AppUserWritePlatformServiceJpaRepositoryImpl.java
@@ -22,6 +22,7 @@ import com.google.common.base.Splitter;
 import com.google.common.collect.Iterables;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -31,8 +32,6 @@ import java.util.Optional;
 import java.util.Set;
 import javax.persistence.PersistenceException;
 import javax.servlet.http.HttpServletRequest;
-
-import com.google.gson.JsonObject;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -370,7 +369,7 @@ public class AppUserWritePlatformServiceJpaRepositoryImpl implements AppUserWrit
 
     @Override
     public AppUser completePasswordReset(String username, String otp, Boolean logoutDevices,
-                                         PlatformPasswordEncoder platformPasswordEncoder) {
+            PlatformPasswordEncoder platformPasswordEncoder) {
         AppUser appUser = this.appUserRepository.findAppUserByName(username);
         if (appUser == null) {
             throw new UsernameNotFoundException(username);
@@ -486,7 +485,6 @@ public class AppUserWritePlatformServiceJpaRepositoryImpl implements AppUserWrit
         String token = new RandomOTPGenerator(otpLength).generate();
         return OTPRequest.create(token, tokenLiveTime, extendedAccessToken, deliveryMethod);
     }
-
 
     /*
      * Return an exception to throw, no matter what the data integrity issue is.

--- a/fineract-provider/src/main/resources/application.properties
+++ b/fineract-provider/src/main/resources/application.properties
@@ -23,7 +23,7 @@ fineract.node-id=${FINERACT_NODE_ID:1}
 
 fineract.security.basicauth.enabled=${FINERACT_SECURITY_BASICAUTH_ENABLED:true}
 fineract.security.oauth.enabled=${FINERACT_SECURITY_OAUTH_ENABLED:false}
-fineract.security.2fa.enabled=${FINERACT_SECURITY_2FA_ENABLED:true}
+fineract.security.2fa.enabled=${FINERACT_SECURITY_2FA_ENABLED:false}
 
 fineract.tenant.host=${FINERACT_DEFAULT_TENANTDB_HOSTNAME:localhost}
 fineract.tenant.port=${FINERACT_DEFAULT_TENANTDB_PORT:3306}

--- a/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
@@ -164,4 +164,5 @@
     <include file="parts/0140-ACCOUNTING_MANUAL_ENTRTIES CONFIGURATION.xml" relativeToChangelogFile="true"/>
     <include file="parts/FS_182_FIX_RESCHEDULED_LOANS_REPORT.xml" relativeToChangelogFile="true"/>
     <include file="parts/0148-FBR_ADD_2FA_CONFIGURATIONS.xml" relativeToChangelogFile="true"/>
+    <include file="parts/0149-PUENTE_AL_EXITO_COMMITTEE_APPROVAL_LIMITS.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
@@ -165,4 +165,6 @@
     <include file="parts/FS_182_FIX_RESCHEDULED_LOANS_REPORT.xml" relativeToChangelogFile="true"/>
     <include file="parts/0148-FBR_ADD_2FA_CONFIGURATIONS.xml" relativeToChangelogFile="true"/>
     <include file="parts/PUE_01_11_25_add_new_column_to_prequalification_tables.xml" relativeToChangelogFile="true"/>
+    <include file="parts/PUE_04_11_25_add_new_code_rejected_prequalification.xml" relativeToChangelogFile="true"/>
+    <include file="parts/PUE_05_11_25_add_new_colum_prequalification_log.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/0149-PUENTE_AL_EXITO_COMMITTEE_APPROVAL_LIMITS.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/0149-PUENTE_AL_EXITO_COMMITTEE_APPROVAL_LIMITS.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+    <changeSet author="fineract" id="1">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="committee_approval_limits"/>
+            </not>
+        </preConditions>
+        <createTable tableName="committee_approval_limits">
+            <column autoIncrement="true" name="id" type="BIGINT">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="committee_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="from_amount" type="numeric">
+                <constraints nullable="false"/>
+            </column>
+            <column name="to_amount" type="numeric"/>
+            <column name="condition" type="varchar(20)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="limit" type="integer">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_at" type="datetime" defaultValue="now()">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_by" type="bigint">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+</databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/PUE_04_11_25_add_new_code_rejected_prequalification.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/PUE_04_11_25_add_new_code_rejected_prequalification.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+    <changeSet id="Jacobo Vargas" author="1">
+        <insert tableName="m_code">
+            <column name="code_name" value="Rejected Prequalification Options"/>
+            <column name="is_system_defined" valueBoolean="true"/>
+        </insert>
+
+        <insert tableName="m_code_value">
+            <column name="code_id" valueComputed="(SELECT id FROM m_code WHERE code_name = 'Rejected Prequalification Options')"/>
+            <column name="code_value" value="Falta de capacidad de pago"/>
+            <column name="order_position" value="1"/>
+            <column name="is_active" valueBoolean="true"/>
+        </insert>
+
+        <insert tableName="m_code_value">
+            <column name="code_id" valueComputed="(SELECT id FROM m_code WHERE code_name = 'Rejected Prequalification Options')"/>
+            <column name="code_value" value="Prestanombre"/>
+            <column name="order_position" value="2"/>
+            <column name="is_active" valueBoolean="true"/>
+        </insert>
+
+        <insert tableName="m_code_value">
+            <column name="code_id" valueComputed="(SELECT id FROM m_code WHERE code_name = 'Rejected Prequalification Options')"/>
+            <column name="code_value" value="Sobre endeudamiento"/>
+            <column name="order_position" value="3"/>
+            <column name="is_active" valueBoolean="true"/>
+        </insert>
+
+        <insert tableName="m_code_value">
+            <column name="code_id" valueComputed="(SELECT id FROM m_code WHERE code_name = 'Rejected Prequalification Options')"/>
+            <column name="code_value" value="Mal record crediticio"/>
+            <column name="order_position" value="4"/>
+            <column name="is_active" valueBoolean="true"/>
+        </insert>
+
+        <insert tableName="m_code_value">
+            <column name="code_id" valueComputed="(SELECT id FROM m_code WHERE code_name = 'Rejected Prequalification Options')"/>
+            <column name="code_value" value="Cobertura de garantía insuficiente"/>
+            <column name="order_position" value="5"/>
+            <column name="is_active" valueBoolean="true"/>
+        </insert>
+
+        <insert tableName="m_code_value">
+            <column name="code_id" valueComputed="(SELECT id FROM m_code WHERE code_name = 'Rejected Prequalification Options')"/>
+            <column name="code_value" value="No cumple con el perfil"/>
+            <column name="order_position" value="6"/>
+            <column name="is_active" valueBoolean="true"/>
+        </insert>
+
+        <insert tableName="m_code_value">
+            <column name="code_id" valueComputed="(SELECT id FROM m_code WHERE code_name = 'Rejected Prequalification Options')"/>
+            <column name="code_value" value="Incumplimiento de política por la deudora"/>
+            <column name="order_position" value="7"/>
+            <column name="is_active" valueBoolean="true"/>
+        </insert>
+
+        <insert tableName="m_code_value">
+            <column name="code_id" valueComputed="(SELECT id FROM m_code WHERE code_name = 'Rejected Prequalification Options')"/>
+            <column name="code_value" value="Incumplimiento de política por el fiador"/>
+            <column name="order_position" value="8"/>
+            <column name="is_active" valueBoolean="true"/>
+        </insert>
+
+        <insert tableName="m_code_value">
+            <column name="code_id" valueComputed="(SELECT id FROM m_code WHERE code_name = 'Rejected Prequalification Options')"/>
+            <column name="code_value" value="Otro"/>
+            <column name="order_position" value="9"/>
+            <column name="is_active" valueBoolean="true"/>
+        </insert>
+
+    </changeSet>
+
+</databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/PUE_05_11_25_add_new_colum_prequalification_log.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/PUE_05_11_25_add_new_colum_prequalification_log.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+    <changeSet id="Jacobo Vargas" author="1">
+
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="m_prequalification_status_log" columnName="reason_code_id"/>
+            </not>
+        </preConditions>
+
+        <addColumn tableName="m_prequalification_status_log">
+            <column name="reason_code_id" type="INT"/>
+        </addColumn>
+
+        <addForeignKeyConstraint
+                baseTableName="m_prequalification_status_log"
+                baseColumnNames="reason_code_id"
+                referencedTableName="m_code_value"
+                referencedColumnNames="id"
+                constraintName="fk_prequalification_log_reason_code"
+                onDelete="SET NULL"/>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
## 
This pull request introduces a new feature for managing committee approval limits within the organisation module. It adds new domain, data, repository, and service classes to support storing, retrieving, and mapping approval limits for committees, and integrates these changes into the committee data model and service layer. The most important changes are grouped below:

### Committee Approval Limits Feature

* Added new domain entity `CommitteeApprovalLimits` to represent approval limits for committees, including fields for amount ranges, condition, limit, and audit information. (`CommitteeApprovalLimits.java`)
* Introduced `CommitteeApprovalLimitsRepository` and `CommitteeApprovalLimitsRepositoryWrapper` to handle persistence and error handling for committee approval limits. (`CommitteeApprovalLimitsRepository.java`, `CommitteeApprovalLimitsRepositoryWrapper.java`) [[1]](diffhunk://#diff-b3cd63b8d5e7ed1662d8c455aa55603d5d41e15921a4cd7b2c2fbcac58696b4bR1-R35) [[2]](diffhunk://#diff-c51ed430838a50444b8cb0f7d524ec9f52e03230435777570738b3fa8e1fa314R1-R64)
* Created `CommitteeApprovalsData` data transfer object and `RequiredCommitteeApprovalsMapper` for mapping database rows to approval limit DTOs. (`CommitteeApprovalsData.java`, `RequiredCommitteeApprovalsMapper.java`) [[1]](diffhunk://#diff-e07f4db3acaf0d24dfe9cf437810204c3810242ebe17b4485b2346a06e6cba0bR1-R38) [[2]](diffhunk://#diff-ab8a729e72345843e6e32c0056e17735bc314345dc3468de859ba59b1204d188R1-R60)

### Integration with Committee Data Model and Services

* Updated `CommitteeData` to include a collection of `CommitteeApprovalLimits` and added setter for this field. (`CommitteeData.java`) [[1]](diffhunk://#diff-134f306bfe2bc4e32b75eb75658b219dbeb3f664af0dc4f2de60dcf378cd20bcR24) [[2]](diffhunk://#diff-134f306bfe2bc4e32b75eb75658b219dbeb3f664af0dc4f2de60dcf378cd20bcR36) [[3]](diffhunk://#diff-134f306bfe2bc4e32b75eb75658b219dbeb3f664af0dc4f2de60dcf378cd20bcR71-R73)
* Modified `CommitteeReadPlatformServiceImpl` to inject and use the approval limits repository wrapper, retrieving and setting approval limits when fetching committee data. (`CommitteeReadPlatformServiceImpl.java`) [[1]](diffhunk://#diff-81466ace12f95a0ff34dd1157035a527937770c6b31860440ed4a3cb057ec3deR27) [[2]](diffhunk://#diff-81466ace12f95a0ff34dd1157035a527937770c6b31860440ed4a3cb057ec3deR38-R39) [[3]](diffhunk://#diff-81466ace12f95a0ff34dd1157035a527937770c6b31860440ed4a3cb057ec3deR60-R68) [[4]](diffhunk://#diff-81466ace12f95a0ff34dd1157035a527937770c6b31860440ed4a3cb057ec3deR77) [[5]](diffhunk://#diff-81466ace12f95a0ff34dd1157035a527937770c6b31860440ed4a3cb057ec3deR97-R111)

### Committee API and Constants

* Extended `CommitteeSupportedParameters` enum to include new parameters for approval limits, such as `ABOVE_EXCEPTION_LIMIT`, `BELOW_EXCEPTION_LIMIT`, `CONDITION`, and `LIMIT`, supporting future API enhancements. (`CommitteeConstants.java`)

These changes lay the foundation for more granular and configurable approval workflows within committees, improving flexibility and auditability in the approval process.