### PR TITLE
ITEXT PDF FIX

### DIFF
--- a/fineract-provider/build.gradle
+++ b/fineract-provider/build.gradle
@@ -228,7 +228,7 @@ bootRun {
         implementation 'org.apache.poi:poi:5.2.3'
         implementation 'org.apache.poi:poi-ooxml:5.2.3'
         implementation 'org.apache.poi:poi-ooxml-full:5.2.3'
-
+        implementation 'com.ibm.icu:icu4j:3.4.4'
     }
 }
 

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/promissoryNoteTemplates/PromissoryNoteTemplateFive.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/promissoryNoteTemplates/PromissoryNoteTemplateFive.java
@@ -21,21 +21,20 @@ package org.apache.fineract.infrastructure.dataqueries.service.promissoryNoteTem
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.ibm.icu.text.RuleBasedNumberFormat;
-import com.itextpdf.text.BaseColor;
-import com.itextpdf.text.Document;
-import com.itextpdf.text.Element;
-import com.itextpdf.text.Font;
-import com.itextpdf.text.FontFactory;
-import com.itextpdf.text.Image;
-import com.itextpdf.text.Paragraph;
-import com.itextpdf.text.Phrase;
-import com.itextpdf.text.Rectangle;
-import com.itextpdf.text.pdf.ColumnText;
-import com.itextpdf.text.pdf.PdfContentByte;
-import com.itextpdf.text.pdf.PdfPCell;
-import com.itextpdf.text.pdf.PdfPTable;
-import com.itextpdf.text.pdf.PdfPageEventHelper;
-import com.itextpdf.text.pdf.PdfWriter;
+import com.lowagie.text.Document;
+import com.lowagie.text.Element;
+import com.lowagie.text.Font;
+import com.lowagie.text.FontFactory;
+import com.lowagie.text.Image;
+import com.lowagie.text.Paragraph;
+import com.lowagie.text.Phrase;
+import com.lowagie.text.pdf.ColumnText;
+import com.lowagie.text.pdf.PdfContentByte;
+import com.lowagie.text.pdf.PdfPCell;
+import com.lowagie.text.pdf.PdfPTable;
+import com.lowagie.text.pdf.PdfPageEventHelper;
+import com.lowagie.text.pdf.PdfWriter;
+import java.awt.Color;
 import java.io.ByteArrayOutputStream;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -156,8 +155,8 @@ public class PromissoryNoteTemplateFive {
             document.setMargins(50, 50, 100, 50);
             document.open();
 
-            Font titleFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 14, BaseColor.BLACK);
-            Font normalFont = FontFactory.getFont(FontFactory.HELVETICA, 11, BaseColor.BLACK);
+            Font titleFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 14, Color.BLACK);
+            Font normalFont = FontFactory.getFont(FontFactory.HELVETICA, 11, Color.BLACK);
 
             // Título
             Paragraph title = new Paragraph("PAGARÉ LIBRE DE PROTESTO", titleFont);
@@ -248,14 +247,14 @@ public class PromissoryNoteTemplateFive {
         table.setSpacingBefore(40f);
 
         PdfPCell emptyCell = new PdfPCell();
-        emptyCell.setBorder(Rectangle.NO_BORDER);
+        emptyCell.setBorder(com.lowagie.text.Rectangle.NO_BORDER);
         emptyCell.setHorizontalAlignment(Element.ALIGN_CENTER);
 
-        Font font = FontFactory.getFont(FontFactory.HELVETICA, 11, BaseColor.BLACK);
+        Font font = FontFactory.getFont(FontFactory.HELVETICA, 11, Color.BLACK);
         if (clientName != null) {
             PdfPCell cell1 = new PdfPCell(
                     new Paragraph("F. _________________________________\n\n" + clientName.toUpperCase() + "\n\n" + subtitleOne, font));
-            cell1.setBorder(Rectangle.NO_BORDER);
+            cell1.setBorder(com.lowagie.text.Rectangle.NO_BORDER);
             cell1.setHorizontalAlignment(Element.ALIGN_CENTER);
             table.addCell(cell1);
 
@@ -266,7 +265,7 @@ public class PromissoryNoteTemplateFive {
         if (witnessName != null) {
             PdfPCell cell2 = new PdfPCell(
                     new Paragraph("F. _________________________________\n\n" + witnessName.toUpperCase() + "\n\n" + subtitleTwo, font));
-            cell2.setBorder(Rectangle.NO_BORDER);
+            cell2.setBorder(com.lowagie.text.Rectangle.NO_BORDER);
             cell2.setHorizontalAlignment(Element.ALIGN_CENTER);
             table.addCell(cell2);
         } else {
@@ -295,8 +294,8 @@ public class PromissoryNoteTemplateFive {
                 cb.addImage(logo, false);
 
                 ColumnText.showTextAligned(cb, Element.ALIGN_RIGHT,
-                        new Phrase("THE FRIENDSHIP BRIDGE", FontFactory.getFont(FontFactory.HELVETICA, 8, BaseColor.GRAY)),
-                        document.right(), document.bottom() - 20, 0);
+                        new Phrase("THE FRIENDSHIP BRIDGE", FontFactory.getFont(FontFactory.HELVETICA, 8, Color.GRAY)), document.right(),
+                        document.bottom() - 20, 0);
             } catch (Exception e) {
                 log.info(e.getMessage());
             }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/promissoryNoteTemplates/PromissoryNoteTemplateFour.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/promissoryNoteTemplates/PromissoryNoteTemplateFour.java
@@ -21,21 +21,20 @@ package org.apache.fineract.infrastructure.dataqueries.service.promissoryNoteTem
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.ibm.icu.text.RuleBasedNumberFormat;
-import com.itextpdf.text.BaseColor;
-import com.itextpdf.text.Document;
-import com.itextpdf.text.Element;
-import com.itextpdf.text.Font;
-import com.itextpdf.text.FontFactory;
-import com.itextpdf.text.Image;
-import com.itextpdf.text.Paragraph;
-import com.itextpdf.text.Phrase;
-import com.itextpdf.text.Rectangle;
-import com.itextpdf.text.pdf.ColumnText;
-import com.itextpdf.text.pdf.PdfContentByte;
-import com.itextpdf.text.pdf.PdfPCell;
-import com.itextpdf.text.pdf.PdfPTable;
-import com.itextpdf.text.pdf.PdfPageEventHelper;
-import com.itextpdf.text.pdf.PdfWriter;
+import com.lowagie.text.Document;
+import com.lowagie.text.Element;
+import com.lowagie.text.Font;
+import com.lowagie.text.FontFactory;
+import com.lowagie.text.Image;
+import com.lowagie.text.Paragraph;
+import com.lowagie.text.Phrase;
+import com.lowagie.text.pdf.ColumnText;
+import com.lowagie.text.pdf.PdfContentByte;
+import com.lowagie.text.pdf.PdfPCell;
+import com.lowagie.text.pdf.PdfPTable;
+import com.lowagie.text.pdf.PdfPageEventHelper;
+import com.lowagie.text.pdf.PdfWriter;
+import java.awt.Color;
 import java.io.ByteArrayOutputStream;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -156,8 +155,8 @@ public class PromissoryNoteTemplateFour {
             document.setMargins(50, 50, 100, 50);
             document.open();
 
-            Font titleFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 14, BaseColor.BLACK);
-            Font normalFont = FontFactory.getFont(FontFactory.HELVETICA, 11, BaseColor.BLACK);
+            Font titleFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 14, Color.BLACK);
+            Font normalFont = FontFactory.getFont(FontFactory.HELVETICA, 11, Color.BLACK);
 
             // Título
             Paragraph title = new Paragraph("PAGARÉ LIBRE DE PROTESTO", titleFont);
@@ -247,14 +246,14 @@ public class PromissoryNoteTemplateFour {
         table.setSpacingBefore(40f);
 
         PdfPCell emptyCell = new PdfPCell();
-        emptyCell.setBorder(Rectangle.NO_BORDER);
+        emptyCell.setBorder(com.lowagie.text.Rectangle.NO_BORDER);
         emptyCell.setHorizontalAlignment(Element.ALIGN_CENTER);
 
-        Font font = FontFactory.getFont(FontFactory.HELVETICA, 11, BaseColor.BLACK);
+        Font font = FontFactory.getFont(FontFactory.HELVETICA, 11, Color.BLACK);
         if (clientName != null) {
             PdfPCell cell1 = new PdfPCell(
                     new Paragraph("F. _________________________________\n\n" + clientName.toUpperCase() + "\n\n" + subtitleOne, font));
-            cell1.setBorder(Rectangle.NO_BORDER);
+            cell1.setBorder(com.lowagie.text.Rectangle.NO_BORDER);
             cell1.setHorizontalAlignment(Element.ALIGN_CENTER);
             table.addCell(cell1);
 
@@ -265,7 +264,7 @@ public class PromissoryNoteTemplateFour {
         if (witnessName != null) {
             PdfPCell cell2 = new PdfPCell(
                     new Paragraph("F. _________________________________\n\n" + witnessName.toUpperCase() + "\n\n" + subtitleTwo, font));
-            cell2.setBorder(Rectangle.NO_BORDER);
+            cell2.setBorder(com.lowagie.text.Rectangle.NO_BORDER);
             cell2.setHorizontalAlignment(Element.ALIGN_CENTER);
             table.addCell(cell2);
         } else {
@@ -294,8 +293,8 @@ public class PromissoryNoteTemplateFour {
                 cb.addImage(logo, false);
 
                 ColumnText.showTextAligned(cb, Element.ALIGN_RIGHT,
-                        new Phrase("THE FRIENDSHIP BRIDGE", FontFactory.getFont(FontFactory.HELVETICA, 8, BaseColor.GRAY)),
-                        document.right(), document.bottom() - 20, 0);
+                        new Phrase("THE FRIENDSHIP BRIDGE", FontFactory.getFont(FontFactory.HELVETICA, 8, Color.GRAY)), document.right(),
+                        document.bottom() - 20, 0);
             } catch (Exception e) {
                 log.info(e.getMessage());
             }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/promissoryNoteTemplates/PromissoryNoteTemplateOne.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/promissoryNoteTemplates/PromissoryNoteTemplateOne.java
@@ -21,21 +21,20 @@ package org.apache.fineract.infrastructure.dataqueries.service.promissoryNoteTem
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.ibm.icu.text.RuleBasedNumberFormat;
-import com.itextpdf.text.BaseColor;
-import com.itextpdf.text.Document;
-import com.itextpdf.text.Element;
-import com.itextpdf.text.Font;
-import com.itextpdf.text.FontFactory;
-import com.itextpdf.text.Image;
-import com.itextpdf.text.Paragraph;
-import com.itextpdf.text.Phrase;
-import com.itextpdf.text.Rectangle;
-import com.itextpdf.text.pdf.ColumnText;
-import com.itextpdf.text.pdf.PdfContentByte;
-import com.itextpdf.text.pdf.PdfPCell;
-import com.itextpdf.text.pdf.PdfPTable;
-import com.itextpdf.text.pdf.PdfPageEventHelper;
-import com.itextpdf.text.pdf.PdfWriter;
+import com.lowagie.text.Document;
+import com.lowagie.text.Element;
+import com.lowagie.text.Font;
+import com.lowagie.text.FontFactory;
+import com.lowagie.text.Image;
+import com.lowagie.text.Paragraph;
+import com.lowagie.text.Phrase;
+import com.lowagie.text.pdf.ColumnText;
+import com.lowagie.text.pdf.PdfContentByte;
+import com.lowagie.text.pdf.PdfPCell;
+import com.lowagie.text.pdf.PdfPTable;
+import com.lowagie.text.pdf.PdfPageEventHelper;
+import com.lowagie.text.pdf.PdfWriter;
+import java.awt.Color;
 import java.io.ByteArrayOutputStream;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -153,8 +152,8 @@ public class PromissoryNoteTemplateOne {
             document.setMargins(50, 50, 100, 50);
             document.open();
 
-            Font titleFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 14, BaseColor.BLACK);
-            Font normalFont = FontFactory.getFont(FontFactory.HELVETICA, 11, BaseColor.BLACK);
+            Font titleFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 14, Color.BLACK);
+            Font normalFont = FontFactory.getFont(FontFactory.HELVETICA, 11, Color.BLACK);
 
             // Título
             Paragraph title = new Paragraph("PAGARÉ LIBRE DE PROTESTO", titleFont);
@@ -226,17 +225,17 @@ public class PromissoryNoteTemplateOne {
         table.setWidthPercentage(100);
         table.setSpacingBefore(40f);
 
-        Font font = FontFactory.getFont(FontFactory.HELVETICA, 11, BaseColor.BLACK);
+        Font font = FontFactory.getFont(FontFactory.HELVETICA, 11, Color.BLACK);
 
         PdfPCell cell1 = new PdfPCell(new Paragraph(
                 "F. _________________________________\n\n" + clientName.toUpperCase() + "\n\nPromitente deudora o libradora", font));
-        cell1.setBorder(Rectangle.NO_BORDER);
+        cell1.setBorder(com.lowagie.text.Rectangle.NO_BORDER);
         cell1.setHorizontalAlignment(Element.ALIGN_CENTER);
         table.addCell(cell1);
 
         PdfPCell cell2 = new PdfPCell(
                 new Paragraph("F. _________________________________\n\n" + witnessName.toUpperCase() + "\n\nTestigo", font));
-        cell2.setBorder(Rectangle.NO_BORDER);
+        cell2.setBorder(com.lowagie.text.Rectangle.NO_BORDER);
         cell2.setHorizontalAlignment(Element.ALIGN_CENTER);
         table.addCell(cell2);
 
@@ -262,8 +261,8 @@ public class PromissoryNoteTemplateOne {
                 cb.addImage(logo, false);
 
                 ColumnText.showTextAligned(cb, Element.ALIGN_RIGHT,
-                        new Phrase("THE FRIENDSHIP BRIDGE", FontFactory.getFont(FontFactory.HELVETICA, 8, BaseColor.GRAY)),
-                        document.right(), document.bottom() - 20, 0);
+                        new Phrase("THE FRIENDSHIP BRIDGE", FontFactory.getFont(FontFactory.HELVETICA, 8, Color.GRAY)), document.right(),
+                        document.bottom() - 20, 0);
             } catch (Exception e) {
                 log.info(e.getMessage());
             }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/promissoryNoteTemplates/PromissoryNoteTemplateSix.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/promissoryNoteTemplates/PromissoryNoteTemplateSix.java
@@ -21,21 +21,20 @@ package org.apache.fineract.infrastructure.dataqueries.service.promissoryNoteTem
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.ibm.icu.text.RuleBasedNumberFormat;
-import com.itextpdf.text.BaseColor;
-import com.itextpdf.text.Document;
-import com.itextpdf.text.Element;
-import com.itextpdf.text.Font;
-import com.itextpdf.text.FontFactory;
-import com.itextpdf.text.Image;
-import com.itextpdf.text.Paragraph;
-import com.itextpdf.text.Phrase;
-import com.itextpdf.text.Rectangle;
-import com.itextpdf.text.pdf.ColumnText;
-import com.itextpdf.text.pdf.PdfContentByte;
-import com.itextpdf.text.pdf.PdfPCell;
-import com.itextpdf.text.pdf.PdfPTable;
-import com.itextpdf.text.pdf.PdfPageEventHelper;
-import com.itextpdf.text.pdf.PdfWriter;
+import com.lowagie.text.Document;
+import com.lowagie.text.Element;
+import com.lowagie.text.Font;
+import com.lowagie.text.FontFactory;
+import com.lowagie.text.Image;
+import com.lowagie.text.Paragraph;
+import com.lowagie.text.Phrase;
+import com.lowagie.text.pdf.ColumnText;
+import com.lowagie.text.pdf.PdfContentByte;
+import com.lowagie.text.pdf.PdfPCell;
+import com.lowagie.text.pdf.PdfPTable;
+import com.lowagie.text.pdf.PdfPageEventHelper;
+import com.lowagie.text.pdf.PdfWriter;
+import java.awt.Color;
 import java.io.ByteArrayOutputStream;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -156,8 +155,8 @@ public class PromissoryNoteTemplateSix {
             document.setMargins(50, 50, 100, 50);
             document.open();
 
-            Font titleFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 14, BaseColor.BLACK);
-            Font normalFont = FontFactory.getFont(FontFactory.HELVETICA, 11, BaseColor.BLACK);
+            Font titleFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 14, Color.BLACK);
+            Font normalFont = FontFactory.getFont(FontFactory.HELVETICA, 11, Color.BLACK);
 
             // Título
             Paragraph title = new Paragraph("PAGARÉ LIBRE DE PROTESTO", titleFont);
@@ -248,14 +247,14 @@ public class PromissoryNoteTemplateSix {
         table.setSpacingBefore(40f);
 
         PdfPCell emptyCell = new PdfPCell();
-        emptyCell.setBorder(Rectangle.NO_BORDER);
+        emptyCell.setBorder(com.lowagie.text.Rectangle.NO_BORDER);
         emptyCell.setHorizontalAlignment(Element.ALIGN_CENTER);
 
-        Font font = FontFactory.getFont(FontFactory.HELVETICA, 11, BaseColor.BLACK);
+        Font font = FontFactory.getFont(FontFactory.HELVETICA, 11, Color.BLACK);
         if (clientName != null) {
             PdfPCell cell1 = new PdfPCell(
                     new Paragraph("F. _________________________________\n\n" + clientName.toUpperCase() + "\n\n" + subtitleOne, font));
-            cell1.setBorder(Rectangle.NO_BORDER);
+            cell1.setBorder(com.lowagie.text.Rectangle.NO_BORDER);
             cell1.setHorizontalAlignment(Element.ALIGN_CENTER);
             table.addCell(cell1);
 
@@ -266,7 +265,7 @@ public class PromissoryNoteTemplateSix {
         if (witnessName != null) {
             PdfPCell cell2 = new PdfPCell(
                     new Paragraph("F. _________________________________\n\n" + witnessName.toUpperCase() + "\n\n" + subtitleTwo, font));
-            cell2.setBorder(Rectangle.NO_BORDER);
+            cell2.setBorder(com.lowagie.text.Rectangle.NO_BORDER);
             cell2.setHorizontalAlignment(Element.ALIGN_CENTER);
             table.addCell(cell2);
         } else {
@@ -295,8 +294,8 @@ public class PromissoryNoteTemplateSix {
                 cb.addImage(logo, false);
 
                 ColumnText.showTextAligned(cb, Element.ALIGN_RIGHT,
-                        new Phrase("THE FRIENDSHIP BRIDGE", FontFactory.getFont(FontFactory.HELVETICA, 8, BaseColor.GRAY)),
-                        document.right(), document.bottom() - 20, 0);
+                        new Phrase("THE FRIENDSHIP BRIDGE", FontFactory.getFont(FontFactory.HELVETICA, 8, Color.GRAY)), document.right(),
+                        document.bottom() - 20, 0);
             } catch (Exception e) {
                 log.info(e.getMessage());
             }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/promissoryNoteTemplates/PromissoryNoteTemplateThree.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/promissoryNoteTemplates/PromissoryNoteTemplateThree.java
@@ -21,21 +21,21 @@ package org.apache.fineract.infrastructure.dataqueries.service.promissoryNoteTem
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.ibm.icu.text.RuleBasedNumberFormat;
-import com.itextpdf.text.BaseColor;
-import com.itextpdf.text.Document;
-import com.itextpdf.text.Element;
-import com.itextpdf.text.Font;
-import com.itextpdf.text.FontFactory;
-import com.itextpdf.text.Image;
-import com.itextpdf.text.Paragraph;
-import com.itextpdf.text.Phrase;
-import com.itextpdf.text.Rectangle;
-import com.itextpdf.text.pdf.ColumnText;
-import com.itextpdf.text.pdf.PdfContentByte;
-import com.itextpdf.text.pdf.PdfPCell;
-import com.itextpdf.text.pdf.PdfPTable;
-import com.itextpdf.text.pdf.PdfPageEventHelper;
-import com.itextpdf.text.pdf.PdfWriter;
+import com.lowagie.text.Document;
+import com.lowagie.text.Element;
+import com.lowagie.text.Font;
+import com.lowagie.text.FontFactory;
+import com.lowagie.text.Image;
+import com.lowagie.text.Paragraph;
+import com.lowagie.text.Phrase;
+import com.lowagie.text.Rectangle;
+import com.lowagie.text.pdf.ColumnText;
+import com.lowagie.text.pdf.PdfContentByte;
+import com.lowagie.text.pdf.PdfPCell;
+import com.lowagie.text.pdf.PdfPTable;
+import com.lowagie.text.pdf.PdfPageEventHelper;
+import com.lowagie.text.pdf.PdfWriter;
+import java.awt.Color;
 import java.io.ByteArrayOutputStream;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -156,8 +156,8 @@ public class PromissoryNoteTemplateThree {
             document.setMargins(50, 50, 100, 50);
             document.open();
 
-            Font titleFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 14, BaseColor.BLACK);
-            Font normalFont = FontFactory.getFont(FontFactory.HELVETICA, 11, BaseColor.BLACK);
+            Font titleFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 14, Color.BLACK);
+            Font normalFont = FontFactory.getFont(FontFactory.HELVETICA, 11, Color.BLACK);
 
             // Título
             Paragraph title = new Paragraph("PAGARÉ LIBRE DE PROTESTO", titleFont);
@@ -250,7 +250,8 @@ public class PromissoryNoteTemplateThree {
         emptyCell.setBorder(Rectangle.NO_BORDER);
         emptyCell.setHorizontalAlignment(Element.ALIGN_CENTER);
 
-        Font font = FontFactory.getFont(FontFactory.HELVETICA, 11, BaseColor.BLACK);
+        int baseColor;
+        Font font = FontFactory.getFont(FontFactory.HELVETICA, 11, Color.black);
         if (clientName != null) {
             PdfPCell cell1 = new PdfPCell(
                     new Paragraph("F. _________________________________\n\n" + clientName.toUpperCase() + "\n\n" + subtitleOne, font));
@@ -294,8 +295,8 @@ public class PromissoryNoteTemplateThree {
                 cb.addImage(logo, false);
 
                 ColumnText.showTextAligned(cb, Element.ALIGN_RIGHT,
-                        new Phrase("THE FRIENDSHIP BRIDGE", FontFactory.getFont(FontFactory.HELVETICA, 8, BaseColor.GRAY)),
-                        document.right(), document.bottom() - 20, 0);
+                        new Phrase("THE FRIENDSHIP BRIDGE", FontFactory.getFont(FontFactory.HELVETICA, 8, Color.GRAY)), document.right(),
+                        document.bottom() - 20, 0);
             } catch (Exception e) {
                 log.info(e.getMessage());
             }

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/promissoryNoteTemplates/PromissoryNoteTemplateTwo.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/dataqueries/service/promissoryNoteTemplates/PromissoryNoteTemplateTwo.java
@@ -21,21 +21,20 @@ package org.apache.fineract.infrastructure.dataqueries.service.promissoryNoteTem
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.ibm.icu.text.RuleBasedNumberFormat;
-import com.itextpdf.text.BaseColor;
-import com.itextpdf.text.Document;
-import com.itextpdf.text.Element;
-import com.itextpdf.text.Font;
-import com.itextpdf.text.FontFactory;
-import com.itextpdf.text.Image;
-import com.itextpdf.text.Paragraph;
-import com.itextpdf.text.Phrase;
-import com.itextpdf.text.Rectangle;
-import com.itextpdf.text.pdf.ColumnText;
-import com.itextpdf.text.pdf.PdfContentByte;
-import com.itextpdf.text.pdf.PdfPCell;
-import com.itextpdf.text.pdf.PdfPTable;
-import com.itextpdf.text.pdf.PdfPageEventHelper;
-import com.itextpdf.text.pdf.PdfWriter;
+import com.lowagie.text.Document;
+import com.lowagie.text.Element;
+import com.lowagie.text.Font;
+import com.lowagie.text.FontFactory;
+import com.lowagie.text.Image;
+import com.lowagie.text.Paragraph;
+import com.lowagie.text.Phrase;
+import com.lowagie.text.pdf.ColumnText;
+import com.lowagie.text.pdf.PdfContentByte;
+import com.lowagie.text.pdf.PdfPCell;
+import com.lowagie.text.pdf.PdfPTable;
+import com.lowagie.text.pdf.PdfPageEventHelper;
+import com.lowagie.text.pdf.PdfWriter;
+import java.awt.Color;
 import java.io.ByteArrayOutputStream;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -149,8 +148,8 @@ public class PromissoryNoteTemplateTwo {
             document.setMargins(50, 50, 100, 50);
             document.open();
 
-            Font titleFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 14, BaseColor.BLACK);
-            Font normalFont = FontFactory.getFont(FontFactory.HELVETICA, 11, BaseColor.BLACK);
+            Font titleFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD, 14, Color.BLACK);
+            Font normalFont = FontFactory.getFont(FontFactory.HELVETICA, 11, Color.BLACK);
 
             // Título
             Paragraph title = new Paragraph("PAGARÉ LIBRE DE PROTESTO", titleFont);
@@ -223,14 +222,14 @@ public class PromissoryNoteTemplateTwo {
         table.setSpacingBefore(40f);
 
         PdfPCell emptyCell = new PdfPCell();
-        emptyCell.setBorder(Rectangle.NO_BORDER);
+        emptyCell.setBorder(com.lowagie.text.Rectangle.NO_BORDER);
         emptyCell.setHorizontalAlignment(Element.ALIGN_CENTER);
 
-        Font font = FontFactory.getFont(FontFactory.HELVETICA, 11, BaseColor.BLACK);
+        Font font = FontFactory.getFont(FontFactory.HELVETICA, 11, Color.BLACK);
         if (clientName != null) {
             PdfPCell cell1 = new PdfPCell(
                     new Paragraph("F. _________________________________\n\n" + clientName.toUpperCase() + "\n\n" + subtitleOne, font));
-            cell1.setBorder(Rectangle.NO_BORDER);
+            cell1.setBorder(com.lowagie.text.Rectangle.NO_BORDER);
             cell1.setHorizontalAlignment(Element.ALIGN_CENTER);
             table.addCell(cell1);
 
@@ -241,7 +240,7 @@ public class PromissoryNoteTemplateTwo {
         if (witnessName != null) {
             PdfPCell cell2 = new PdfPCell(
                     new Paragraph("F. _________________________________\n\n" + witnessName.toUpperCase() + "\n\n" + subtitleTwo, font));
-            cell2.setBorder(Rectangle.NO_BORDER);
+            cell2.setBorder(com.lowagie.text.Rectangle.NO_BORDER);
             cell2.setHorizontalAlignment(Element.ALIGN_CENTER);
             table.addCell(cell2);
         } else {
@@ -270,8 +269,8 @@ public class PromissoryNoteTemplateTwo {
                 cb.addImage(logo, false);
 
                 ColumnText.showTextAligned(cb, Element.ALIGN_RIGHT,
-                        new Phrase("THE FRIENDSHIP BRIDGE", FontFactory.getFont(FontFactory.HELVETICA, 8, BaseColor.GRAY)),
-                        document.right(), document.bottom() - 20, 0);
+                        new Phrase("THE FRIENDSHIP BRIDGE", FontFactory.getFont(FontFactory.HELVETICA, 8, Color.GRAY)), document.right(),
+                        document.bottom() - 20, 0);
             } catch (Exception e) {
                 log.info(e.getMessage());
             }


### PR DESCRIPTION
## 
This pull request updates the promissory note PDF generation templates to use the `com.lowagie.text` library (iText 2) instead of `com.itextpdf.text` (iText 5+), and replaces the use of `BaseColor` with `java.awt.Color`. The changes are applied consistently across all promissory note template classes. Additionally, the ICU4J library is added as a dependency.

**Dependency and Library Updates:**

* Switched PDF generation from `com.itextpdf.text` (iText 5+) to `com.lowagie.text` (iText 2) in all promissory note template classes (`PromissoryNoteTemplateOne.java`, `PromissoryNoteTemplateFour.java`, `PromissoryNoteTemplateFive.java`, `PromissoryNoteTemplateSix.java`). (`[[1]](diffhunk://#diff-e92dab2de993c5a5734807b1c6f3b66112c617454e9d84edd3a5c7a544db05e0L24-R37)`, `[[2]](diffhunk://#diff-46394b668189584653828fd349a75925fa3757d6c4352a266e3a4170f1585e07L24-R37)`, `[[3]](diffhunk://#diff-efb302f2fd5d3c6ce6b866d4d25c1fdb1ce9b1e78f26f5e84f2f4a59b809e389L24-R37)`, `[[4]](diffhunk://#diff-ba0d80afbca08a1d60fc585edbec1e3681ea9ca70d632dbe877222dea4da7e70L24-R37)`)
* Replaced usage of `BaseColor` with `java.awt.Color` for font and border color definitions throughout the templates. (`[[1]](diffhunk://#diff-e92dab2de993c5a5734807b1c6f3b66112c617454e9d84edd3a5c7a544db05e0L156-R156)`, `[[2]](diffhunk://#diff-e92dab2de993c5a5734807b1c6f3b66112c617454e9d84edd3a5c7a544db05e0L229-R238)`, `[[3]](diffhunk://#diff-e92dab2de993c5a5734807b1c6f3b66112c617454e9d84edd3a5c7a544db05e0L265-R265)`, `[[4]](diffhunk://#diff-46394b668189584653828fd349a75925fa3757d6c4352a266e3a4170f1585e07L159-R159)`, `[[5]](diffhunk://#diff-46394b668189584653828fd349a75925fa3757d6c4352a266e3a4170f1585e07L250-R256)`, `[[6]](diffhunk://#diff-46394b668189584653828fd349a75925fa3757d6c4352a266e3a4170f1585e07L268-R267)`, `[[7]](diffhunk://#diff-46394b668189584653828fd349a75925fa3757d6c4352a266e3a4170f1585e07L297-R297)`, `[[8]](diffhunk://#diff-efb302f2fd5d3c6ce6b866d4d25c1fdb1ce9b1e78f26f5e84f2f4a59b809e389L159-R159)`, `[[9]](diffhunk://#diff-efb302f2fd5d3c6ce6b866d4d25c1fdb1ce9b1e78f26f5e84f2f4a59b809e389L251-R257)`, `[[10]](diffhunk://#diff-efb302f2fd5d3c6ce6b866d4d25c1fdb1ce9b1e78f26f5e84f2f4a59b809e389L269-R268)`, `[[11]](diffhunk://#diff-efb302f2fd5d3c6ce6b866d4d25c1fdb1ce9b1e78f26f5e84f2f4a59b809e389L298-R298)`, `[[12]](diffhunk://#diff-ba0d80afbca08a1d60fc585edbec1e3681ea9ca70d632dbe877222dea4da7e70L159-R159)`, `[[13]](diffhunk://#diff-ba0d80afbca08a1d60fc585edbec1e3681ea9ca70d632dbe877222dea4da7e70L251-R257)`, `[[14]](diffhunk://#diff-ba0d80afbca08a1d60fc585edbec1e3681ea9ca70d632dbe877222dea4da7e70L269-R268)`, `[[15]](diffhunk://#diff-ba0d80afbca08a1d60fc585edbec1e3681ea9ca70d632dbe877222dea4da7e70L298-R298)`)
* Updated references to rectangle border constants to use `com.lowagie.text.Rectangle.NO_BORDER`. (`[[1]](diffhunk://#diff-e92dab2de993c5a5734807b1c6f3b66112c617454e9d84edd3a5c7a544db05e0L229-R238)`, `[[2]](diffhunk://#diff-e92dab2de993c5a5734807b1c6f3b66112c617454e9d84edd3a5c7a544db05e0L229-R238)`, `[[3]](diffhunk://#diff-46394b668189584653828fd349a75925fa3757d6c4352a266e3a4170f1585e07L250-R256)`, `[[4]](diffhunk://#diff-46394b668189584653828fd349a75925fa3757d6c4352a266e3a4170f1585e07L250-R256)`, `[[5]](diffhunk://#diff-efb302f2fd5d3c6ce6b866d4d25c1fdb1ce9b1e78f26f5e84f2f4a59b809e389L251-R257)`, `[[6]](diffhunk://#diff-efb302f2fd5d3c6ce6b866d4d25c1fdb1ce9b1e78f26f5e84f2f4a59b809e389L251-R257)`, `[[7]](diffhunk://#diff-ba0d80afbca08a1d60fc585edbec1e3681ea9ca70d632dbe877222dea4da7e70L251-R257)`, `[[8]](diffhunk://#diff-ba0d80afbca08a1d60fc585edbec1e3681ea9ca70d632dbe877222dea4da7e70L251-R257)`)
* Added `com.ibm.icu:icu4j:3.4.4` as a new dependency in the build configuration. (`[fineract-provider/build.gradleL231-R231](diffhunk://#diff-b5d812c2bd53fd63d245df1489ac0cd3de86d456ed742d3355ab52810b158c87L231-R231)`)

These changes ensure compatibility with the older iText library and standardize color handling, while also introducing ICU4J for improved internationalization support.