### PR TITLE
Feature/puente al exito

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/data/LoanAccountData.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/data/LoanAccountData.java
@@ -286,6 +286,7 @@ public final class LoanAccountData {
     private Collection<CodeValueData> cancellationReasonOptions;
     private GroupLoanAdditionalData groupLoanAdditionalData;
     private List<EconomicSectorData> economicSectorOptions;
+    private Collection<CodeValueData> paeRequiredGuaranteeOptions;
 
     public static LoanAccountData disburseLoanByCheques(final Collection<AgencyData> agencyOptions,
             final Collection<CenterData> centerOptions, final Collection<GroupGeneralData> groupOption,
@@ -434,7 +435,7 @@ public final class LoanAccountData {
                 isVariableInstallmentsAllowed, minimumGap, maximumGap, subStatus, canUseForTopup, clientActiveLoanOptions, isTopup,
                 closureLoanId, closureLoanAccountNo, topupAmount, isEqualAmortization, rates, isRatesEnabled,
                 fixedPrincipalPercentagePerInstallment, delinquent, contractNo, agencyOptions, centerOptions, groupOption,
-                facilitatorOptions, disbursementMethodOptions, requiredGuaranteeAmount, actualGuaranteeAmount, null);
+                facilitatorOptions, disbursementMethodOptions, requiredGuaranteeAmount, actualGuaranteeAmount, null, null);
     }
 
     public static LoanAccountData importInstanceIndividual(EnumOptionData loanTypeEnumOption, Long clientId, Long productId,
@@ -841,7 +842,8 @@ public final class LoanAccountData {
                 acc.subStatus, acc.canUseForTopup, acc.clientActiveLoanOptions, acc.isTopup, acc.closureLoanId, acc.closureLoanAccountNo,
                 acc.topupAmount, acc.isEqualAmortization, acc.rates, acc.isRatesEnabled, acc.fixedPrincipalPercentagePerInstallment,
                 acc.delinquent, acc.contractNo, acc.agencyOptions, acc.centerOptions, acc.groupOptions, acc.facilitatorOptions,
-                acc.disbursementMethodOptions, acc.requiredGuaranteeAmount, acc.actualGuaranteeAmount, groupLoanAdditionalData);
+                acc.disbursementMethodOptions, acc.requiredGuaranteeAmount, acc.actualGuaranteeAmount, groupLoanAdditionalData,
+                acc.paeRequiredGuaranteeOptions);
     }
 
     public Integer getRowIndex() {
@@ -1038,7 +1040,7 @@ public final class LoanAccountData {
                 isVariableInstallmentsAllowed, minimumGap, maximumGap, subStatus, canUseForTopup, clientActiveLoanOptions, isTopup,
                 closureLoanId, closureLoanAccountNo, topupAmount, isEqualAmortization, rates, isRatesEnabled,
                 fixedPrincipalPercentagePerInstallment, delinquent, contractNo, agencyOptions, centerOptions, groupOption,
-                facilitatorOptions, disbursementMethodOptions, requiredGuaranteeAmount, actualGuaranteeAmount, null);
+                facilitatorOptions, disbursementMethodOptions, requiredGuaranteeAmount, actualGuaranteeAmount, null, null);
     }
 
     /**
@@ -1193,7 +1195,7 @@ public final class LoanAccountData {
                 isVariableInstallmentsAllowed, minimumGap, maximumGap, subStatus, canUseForTopup, clientActiveLoanOptions, isTopup,
                 closureLoanId, closureLoanAccountNo, topupAmount, isEqualAmortization, rates, isRatesEnabled,
                 fixedPrincipalPercentagePerInstallment, delinquent, contractNo, agencyOptions, centerOptions, groupOption,
-                facilitatorOptions, disbursementMethodOptions, requiredGuaranteeAmount, actualGuaranteeAmount, null);
+                facilitatorOptions, disbursementMethodOptions, requiredGuaranteeAmount, actualGuaranteeAmount, null, null);
     }
 
     public static LoanAccountData populateClientDefaults(final LoanAccountData acc, final LoanAccountData clientAcc) {
@@ -1226,7 +1228,7 @@ public final class LoanAccountData {
                 acc.closureLoanId, acc.closureLoanAccountNo, acc.topupAmount, acc.isEqualAmortization, acc.rates, acc.isRatesEnabled,
                 acc.fixedPrincipalPercentagePerInstallment, acc.delinquent, acc.contractNo, acc.agencyOptions, acc.centerOptions,
                 acc.groupOptions, acc.facilitatorOptions, acc.disbursementMethodOptions, acc.requiredGuaranteeAmount,
-                acc.actualGuaranteeAmount, acc.groupLoanAdditionalData);
+                acc.actualGuaranteeAmount, acc.groupLoanAdditionalData, acc.paeRequiredGuaranteeOptions);
     }
 
     /**
@@ -1383,7 +1385,7 @@ public final class LoanAccountData {
                 isVariableInstallmentsAllowed, minimumGap, maximumGap, subStatus, canUseForTopup, clientActiveLoanOptions, isTopup,
                 closureLoanId, closureLoanAccountNo, topupAmount, isEqualAmortization, rates, isRatesEnabled,
                 fixedPrincipalPercentagePerInstallment, delinquent, contractNo, agencyOptions, centerOptions, groupOption,
-                facilitatorOptions, disbursementMethodOptions, requiredGuaranteeAmount, actualGuaranteeAmount, null);
+                facilitatorOptions, disbursementMethodOptions, requiredGuaranteeAmount, actualGuaranteeAmount, null, null);
     }
 
     public static LoanAccountData populateGroupDefaults(final LoanAccountData acc, final LoanAccountData groupAcc) {
@@ -1415,7 +1417,7 @@ public final class LoanAccountData {
                 acc.closureLoanId, acc.closureLoanAccountNo, acc.topupAmount, acc.isEqualAmortization, acc.rates, acc.isRatesEnabled,
                 acc.fixedPrincipalPercentagePerInstallment, acc.delinquent, acc.contractNo, acc.agencyOptions, acc.centerOptions,
                 acc.groupOptions, acc.facilitatorOptions, acc.disbursementMethodOptions, acc.requiredGuaranteeAmount,
-                acc.actualGuaranteeAmount, acc.groupLoanAdditionalData);
+                acc.actualGuaranteeAmount, acc.groupLoanAdditionalData, acc.paeRequiredGuaranteeOptions);
     }
 
     public static LoanAccountData loanProductWithTemplateDefaults(final LoanProductData product,
@@ -1427,7 +1429,8 @@ public final class LoanAccountData {
             final Collection<EnumOptionData> interestTypeOptions, final Collection<EnumOptionData> interestCalculationPeriodTypeOptions,
             final Collection<FundData> fundOptions, final Collection<ChargeData> chargeOptions,
             final Collection<CodeValueData> loanPurposeOptions, final Collection<CodeValueData> loanCollateralOptions,
-            final Integer loanCycleNumber, final Collection<LoanAccountSummaryData> clientActiveLoanOptions) {
+            final Integer loanCycleNumber, final Collection<LoanAccountSummaryData> clientActiveLoanOptions,
+            Collection<CodeValueData> paeRequiredGuaranteeOptions) {
 
         final Long id = null;
         final String accountNo = null;
@@ -1592,7 +1595,8 @@ public final class LoanAccountData {
                 product.getMaximumGapBetweenInstallments(), subStatus, canUseForTopup, clientActiveLoanOptions, isTopup, closureLoanId,
                 closureLoanAccountNo, topupAmount, product.isEqualAmortization(), rates, isRatesEnabled,
                 product.getFixedPrincipalPercentagePerInstallment(), delinquent, contractNo, agencyOptions, centerOptions, groupOption,
-                facilitatorOptions, disbursementMethodOptions, requiredGuaranteeAmount, actualGuaranteeAmount, null);
+                facilitatorOptions, disbursementMethodOptions, requiredGuaranteeAmount, actualGuaranteeAmount, null,
+                paeRequiredGuaranteeOptions);
     }
 
     public static LoanAccountData populateLoanProductDefaults(final LoanAccountData acc, final LoanProductData product) {
@@ -1669,7 +1673,7 @@ public final class LoanAccountData {
                 acc.closureLoanId, acc.closureLoanAccountNo, acc.topupAmount, product.isEqualAmortization(), acc.rates, acc.isRatesEnabled,
                 product.getFixedPrincipalPercentagePerInstallment(), delinquent, acc.contractNo, agencyOptions, centerOptions, groupOption,
                 facilitatorOptions, disbursementMethodOptions, acc.requiredGuaranteeAmount, acc.actualGuaranteeAmount,
-                acc.groupLoanAdditionalData);
+                acc.groupLoanAdditionalData, acc.paeRequiredGuaranteeOptions);
     }
 
     /*
@@ -1768,7 +1772,7 @@ public final class LoanAccountData {
                 maximumGap, subStatus, canUseForTopup, clientActiveLoanOptions, isTopup, closureLoanId, closureLoanAccountNo, topupAmount,
                 isEqualAmortization, rates, isRatesEnabled, fixedPrincipalPercentagePerInstallment, delinquent, contractNo, agencyOptions,
                 centerOptions, groupOption, facilitatorOptions, disbursementMethodOptions, requiredGuaranteeAmount, actualGuaranteeAmount,
-                null);
+                null, null);
     }
 
     /*
@@ -1824,7 +1828,7 @@ public final class LoanAccountData {
                 acc.closureLoanAccountNo, acc.topupAmount, acc.isEqualAmortization, rates, isRatesEnabled,
                 acc.fixedPrincipalPercentagePerInstallment, delinquent, acc.contractNo, acc.agencyOptions, acc.centerOptions,
                 acc.groupOptions, acc.facilitatorOptions, acc.disbursementMethodOptions, acc.requiredGuaranteeAmount,
-                acc.actualGuaranteeAmount, acc.groupLoanAdditionalData);
+                acc.actualGuaranteeAmount, acc.groupLoanAdditionalData, acc.paeRequiredGuaranteeOptions);
         loanAccountData.setPrequalificationId(acc.prequalificationId);
         return loanAccountData;
 
@@ -1872,7 +1876,7 @@ public final class LoanAccountData {
                 acc.closureLoanId, acc.closureLoanAccountNo, acc.topupAmount, acc.isEqualAmortization, acc.rates, acc.isRatesEnabled,
                 acc.fixedPrincipalPercentagePerInstallment, acc.delinquent, acc.contractNo, acc.agencyOptions, acc.centerOptions,
                 acc.groupOptions, acc.facilitatorOptions, acc.disbursementMethodOptions, acc.requiredGuaranteeAmount,
-                acc.actualGuaranteeAmount, acc.groupLoanAdditionalData);
+                acc.actualGuaranteeAmount, acc.groupLoanAdditionalData, acc.paeRequiredGuaranteeOptions);
     }
 
     public static LoanAccountData associateMemberVariations(final LoanAccountData acc, final Map<Long, Integer> memberLoanCycle) {
@@ -1940,7 +1944,7 @@ public final class LoanAccountData {
                 acc.closureLoanId, acc.closureLoanAccountNo, acc.topupAmount, acc.isEqualAmortization, acc.rates, acc.isRatesEnabled,
                 acc.fixedPrincipalPercentagePerInstallment, acc.delinquent, acc.contractNo, acc.agencyOptions, acc.centerOptions,
                 acc.groupOptions, acc.facilitatorOptions, acc.disbursementMethodOptions, acc.requiredGuaranteeAmount,
-                acc.actualGuaranteeAmount, acc.groupLoanAdditionalData);
+                acc.actualGuaranteeAmount, acc.groupLoanAdditionalData, acc.paeRequiredGuaranteeOptions);
     }
 
     public static LoanAccountData withInterestRecalculationCalendarData(final LoanAccountData acc, final CalendarData calendarData,
@@ -1976,7 +1980,7 @@ public final class LoanAccountData {
                 acc.closureLoanId, acc.closureLoanAccountNo, acc.topupAmount, acc.isEqualAmortization, acc.rates, acc.isRatesEnabled,
                 acc.fixedPrincipalPercentagePerInstallment, acc.delinquent, acc.contractNo, acc.agencyOptions, acc.centerOptions,
                 acc.groupOptions, acc.facilitatorOptions, acc.disbursementMethodOptions, acc.requiredGuaranteeAmount,
-                acc.actualGuaranteeAmount, acc.groupLoanAdditionalData);
+                acc.actualGuaranteeAmount, acc.groupLoanAdditionalData, acc.paeRequiredGuaranteeOptions);
     }
 
     public static LoanAccountData withLoanCalendarData(final LoanAccountData acc, final CalendarData calendarData) {
@@ -2007,7 +2011,7 @@ public final class LoanAccountData {
                 acc.closureLoanId, acc.closureLoanAccountNo, acc.topupAmount, acc.isEqualAmortization, acc.rates, acc.isRatesEnabled,
                 acc.fixedPrincipalPercentagePerInstallment, acc.delinquent, acc.contractNo, acc.agencyOptions, acc.centerOptions,
                 acc.groupOptions, acc.facilitatorOptions, acc.disbursementMethodOptions, acc.requiredGuaranteeAmount,
-                acc.actualGuaranteeAmount, acc.groupLoanAdditionalData);
+                acc.actualGuaranteeAmount, acc.groupLoanAdditionalData, acc.paeRequiredGuaranteeOptions);
     }
 
     public static LoanAccountData withOriginalSchedule(final LoanAccountData acc, final LoanScheduleData originalSchedule) {
@@ -2039,7 +2043,7 @@ public final class LoanAccountData {
                 acc.closureLoanId, acc.closureLoanAccountNo, acc.topupAmount, acc.isEqualAmortization, acc.rates, acc.isRatesEnabled,
                 acc.fixedPrincipalPercentagePerInstallment, acc.delinquent, acc.contractNo, acc.agencyOptions, acc.centerOptions,
                 acc.groupOptions, acc.facilitatorOptions, acc.disbursementMethodOptions, acc.requiredGuaranteeAmount,
-                acc.actualGuaranteeAmount, acc.groupLoanAdditionalData);
+                acc.actualGuaranteeAmount, acc.groupLoanAdditionalData, acc.paeRequiredGuaranteeOptions);
     }
 
     private LoanAccountData(final Long id, //
@@ -2096,7 +2100,8 @@ public final class LoanAccountData {
             final String contractNo, final Collection<AgencyData> agencyOptions, final Collection<CenterData> centerOptions,
             final Collection<GroupGeneralData> groupOptions, final Collection<AppUserData> facilitatorOptions,
             final Collection<EnumOptionData> disbursementMethodOptions, BigDecimal requiredGuaranteeAmount,
-            final BigDecimal actualGuaranteeAmount, GroupLoanAdditionalData groupLoanAdditionalData) {
+            final BigDecimal actualGuaranteeAmount, GroupLoanAdditionalData groupLoanAdditionalData,
+            Collection<CodeValueData> paeRequiredGuaranteeOptions) {
 
         this.id = id;
         this.accountNo = accountNo;
@@ -2294,6 +2299,7 @@ public final class LoanAccountData {
         this.actualGuaranteeAmount = actualGuaranteeAmount;
         this.documentTypeOptions = null;
         this.groupLoanAdditionalData = groupLoanAdditionalData;
+        this.paeRequiredGuaranteeOptions = paeRequiredGuaranteeOptions;
     }
 
     public RepaymentScheduleRelatedLoanData repaymentScheduleRelatedData() {

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanReadPlatformServiceImpl.java
@@ -133,6 +133,7 @@ import org.apache.fineract.portfolio.loanaccount.loanschedule.data.OverdueLoanSc
 import org.apache.fineract.portfolio.loanproduct.data.LoanProductData;
 import org.apache.fineract.portfolio.loanproduct.data.TransactionProcessingStrategyData;
 import org.apache.fineract.portfolio.loanproduct.domain.InterestMethod;
+import org.apache.fineract.portfolio.loanproduct.domain.LoanProductOwnerType;
 import org.apache.fineract.portfolio.loanproduct.service.LoanDropdownReadPlatformService;
 import org.apache.fineract.portfolio.loanproduct.service.LoanEnumerations;
 import org.apache.fineract.portfolio.loanproduct.service.LoanProductReadPlatformService;
@@ -1647,11 +1648,18 @@ public class LoanReadPlatformServiceImpl implements LoanReadPlatformService {
         } else if (loanProduct.canUseForTopup() && groupId != null) {
             activeLoanOptions = this.accountDetailsReadPlatformService.retrieveGroupActiveLoanAccountSummary(groupId);
         }
+        // for product that is PAE add the required guarantee options
+        Collection<CodeValueData> paeRequiredGuaranteeOptions = null;
+        if (loanProduct.getOwnerTypeOption() != null
+                && loanProduct.getOwnerTypeOption().getId().intValue() == LoanProductOwnerType.PAE.getValue()) {
+            paeRequiredGuaranteeOptions = this.codeValueReadPlatformService.retrieveCodeValuesByCode("PaeRequiredGuarantees");
+        }
 
         return LoanAccountData.loanProductWithTemplateDefaults(loanProduct, loanTermFrequencyTypeOptions, repaymentFrequencyTypeOptions,
                 repaymentFrequencyNthDayTypeOptions, repaymentFrequencyDaysOfWeekTypeOptions, repaymentStrategyOptions,
                 interestRateFrequencyTypeOptions, amortizationTypeOptions, interestTypeOptions, interestCalculationPeriodTypeOptions,
-                fundOptions, chargeOptions, loanPurposeOptions, loanCollateralOptions, loanCycleCounter, activeLoanOptions);
+                fundOptions, chargeOptions, loanPurposeOptions, loanCollateralOptions, loanCycleCounter, activeLoanOptions,
+                paeRequiredGuaranteeOptions);
     }
 
     @Override

--- a/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
@@ -173,4 +173,5 @@
     <include file="parts/PUE_08_11_25_Add_committees_permissions.xml" relativeToChangelogFile="true"/>
     <include file="parts/0150-PUENTE_AL_EXITO_RENEGOTIATIONS.xml" relativeToChangelogFile="true"/>
     <include file="parts/PUE_20_11_25_add_limit_amount_settings.xml" relativeToChangelogFile="true"/>
+    <include file="parts/PUE_27_11_25_ADD_PAE_REQUIRED_GUARANTEES.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/PUE_27_11_25_ADD_PAE_REQUIRED_GUARANTEES.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/PUE_27_11_25_ADD_PAE_REQUIRED_GUARANTEES.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+    <changeSet id="fineract" author="1">
+        <insert tableName="m_code">
+            <column name="code_name" value="PaeRequiredGuarantees"/>
+            <column name="is_system_defined" valueBoolean="true"/>
+        </insert>
+
+        <insert tableName="m_code_value">
+            <column name="code_id" valueComputed="(SELECT id FROM m_code WHERE code_name = 'PaeRequiredGuarantees')"/>
+            <column name="code_value" value="Sin guarantia"/>
+            <column name="order_position" value="1"/>
+            <column name="is_active" valueBoolean="true"/>
+        </insert>
+        <insert tableName="m_code_value">
+            <column name="code_id" valueComputed="(SELECT id FROM m_code WHERE code_name = 'PaeRequiredGuarantees')"/>
+            <column name="code_value" value="Fiador asalariado"/>
+            <column name="order_position" value="1"/>
+            <column name="is_active" valueBoolean="true"/>
+        </insert>
+        <insert tableName="m_code_value">
+            <column name="code_id" valueComputed="(SELECT id FROM m_code WHERE code_name = 'PaeRequiredGuarantees')"/>
+            <column name="code_value" value="Fiador empresario"/>
+            <column name="order_position" value="1"/>
+            <column name="is_active" valueBoolean="true"/>
+        </insert>
+        <insert tableName="m_code_value">
+            <column name="code_id" valueComputed="(SELECT id FROM m_code WHERE code_name = 'PaeRequiredGuarantees')"/>
+            <column name="code_value" value="Fiador moral"/>
+            <column name="order_position" value="1"/>
+            <column name="is_active" valueBoolean="true"/>
+        </insert>
+        <insert tableName="m_code_value">
+            <column name="code_id" valueComputed="(SELECT id FROM m_code WHERE code_name = 'PaeRequiredGuarantees')"/>
+            <column name="code_value" value="Prendaria"/>
+            <column name="order_position" value="1"/>
+            <column name="is_active" valueBoolean="true"/>
+        </insert>
+        <insert tableName="m_code_value">
+            <column name="code_id" valueComputed="(SELECT id FROM m_code WHERE code_name = 'PaeRequiredGuarantees')"/>
+            <column name="code_value" value="Derechos posesorios"/>
+            <column name="order_position" value="1"/>
+            <column name="is_active" valueBoolean="true"/>
+        </insert>
+        <insert tableName="m_code_value">
+            <column name="code_id" valueComputed="(SELECT id FROM m_code WHERE code_name = 'PaeRequiredGuarantees')"/>
+            <column name="code_value" value="Hipoteca"/>
+            <column name="order_position" value="1"/>
+            <column name="is_active" valueBoolean="true"/>
+        </insert>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
## 
This pull request adds support for handling "PAE required guarantee options" in the `LoanAccountData` class and its related service logic. The main change is the introduction of a new field, `paeRequiredGuaranteeOptions`, which is populated and passed through various factory and utility methods to ensure that this data is available wherever `LoanAccountData` is constructed or manipulated.

**Enhancements to LoanAccountData for PAE required guarantees:**

* Added a new field `paeRequiredGuaranteeOptions` of type `Collection<CodeValueData>` to the `LoanAccountData` class and updated the main constructor to accept this new parameter. 

* In `LoanReadPlatformServiceImpl`, added logic to populate `paeRequiredGuaranteeOptions` when the loan product's owner type is PAE, using the code value "PaeRequiredGuarantees". This collection is then passed to `LoanAccountData.loanProductWithTemplateDefaults`. 

These changes ensure that the system can handle and expose required guarantee options for PAE-type loan products throughout the loan account data lifecycle.