### PR TITLE
Feature/puente al exito

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/commands/service/CommandWrapperBuilder.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/commands/service/CommandWrapperBuilder.java
@@ -4010,4 +4010,19 @@ public class CommandWrapperBuilder {
         this.href = "/savingsaccounts/" + accountId + "rebalance";
         return this;
     }
+
+    public CommandWrapperBuilder createPaeDocuments() {
+        this.actionName = "ADD";
+        this.entityName = "PAE_DOCUMENTS";
+        this.href = "/paedocumentation";
+        return this;
+    }
+
+    public CommandWrapperBuilder deletePaeDocuments(final Long documentId) {
+        this.actionName = "DELETE";
+        this.entityName = "PAE_DOCUMENTS";
+        this.entityId = documentId;
+        this.href = "/paedocumentation/" + documentId;
+        return this;
+    }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/paedocumentation/api/PaeRequiredDocumentationApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/paedocumentation/api/PaeRequiredDocumentationApiResource.java
@@ -1,0 +1,144 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.organisation.paedocumentation.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.UriInfo;
+import org.apache.fineract.commands.domain.CommandWrapper;
+import org.apache.fineract.commands.service.CommandWrapperBuilder;
+import org.apache.fineract.commands.service.PortfolioCommandSourceWritePlatformService;
+import org.apache.fineract.infrastructure.core.api.ApiRequestParameterHelper;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.apache.fineract.infrastructure.core.serialization.ApiRequestJsonSerializationSettings;
+import org.apache.fineract.infrastructure.core.serialization.DefaultToApiJsonSerializer;
+import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
+import org.apache.fineract.organisation.paedocumentation.data.PaeRequiredDocumentData;
+import org.apache.fineract.organisation.paedocumentation.service.PaeRequiredDocumentReadPlatformService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+@Path("/paedocumentation")
+@Component
+@Scope("singleton")
+@Tag(name = "PAE Required Documents", description = "Manage PAE required documents per category")
+public class PaeRequiredDocumentationApiResource {
+
+    private final Set<String> responseDataParameters = new HashSet<>(
+            Arrays.asList("id", "categoryId", "documentName", "description", "acceptedFormat"));
+
+    private final String resourceNameForPermissions = "PAE_DOCUMENTS";
+
+    private final PlatformSecurityContext context;
+    private final PaeRequiredDocumentReadPlatformService readPlatformService;
+    private final DefaultToApiJsonSerializer<PaeRequiredDocumentData> toApiJsonSerializer;
+    private final DefaultToApiJsonSerializer<CommandProcessingResult> resultSerializer;
+    private final ApiRequestParameterHelper apiRequestParameterHelper;
+    private final PortfolioCommandSourceWritePlatformService commandsSourceWritePlatformService;
+
+    @Autowired
+    public PaeRequiredDocumentationApiResource(PlatformSecurityContext context, PaeRequiredDocumentReadPlatformService readPlatformService,
+            DefaultToApiJsonSerializer<PaeRequiredDocumentData> toApiJsonSerializer,
+            DefaultToApiJsonSerializer<CommandProcessingResult> resultSerializer, ApiRequestParameterHelper apiRequestParameterHelper,
+            PortfolioCommandSourceWritePlatformService commandsSourceWritePlatformService) {
+        this.context = context;
+        this.readPlatformService = readPlatformService;
+        this.toApiJsonSerializer = toApiJsonSerializer;
+        this.resultSerializer = resultSerializer;
+        this.apiRequestParameterHelper = apiRequestParameterHelper;
+        this.commandsSourceWritePlatformService = commandsSourceWritePlatformService;
+    }
+
+    @GET
+    @Consumes({ MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.APPLICATION_JSON })
+    @Operation(summary = "List required documents by category", description = "Retrieve PAE required documents for a given category (code value id)")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(array = @ArraySchema(schema = @Schema(implementation = PaeRequiredDocumentationApiResourceSwagger.GetPaeRequiredDocumentsResponse.class)))) })
+    public String retrieveByCategory(@Context UriInfo uriInfo,
+            @QueryParam("categoryId") @Parameter(description = "categoryId", required = true) Long categoryId) {
+
+        this.context.authenticatedUser().validateHasReadPermission(this.resourceNameForPermissions);
+
+        List<PaeRequiredDocumentData> documents = readPlatformService.retrieveByCategory(categoryId);
+        ApiRequestJsonSerializationSettings settings = this.apiRequestParameterHelper.process(uriInfo.getQueryParameters());
+        return this.toApiJsonSerializer.serialize(settings, documents, responseDataParameters);
+    }
+
+    @POST
+    @Consumes({ MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.APPLICATION_JSON })
+    @Operation(summary = "Create a required document for a category")
+    @RequestBody(required = true, content = @Content(schema = @Schema(implementation = PaeRequiredDocumentationApiResourceSwagger.PostPaeRequiredDocumentRequest.class)))
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = PaeRequiredDocumentationApiResourceSwagger.PostPaeRequiredDocumentResponse.class))) })
+    public String createRequiredDocument(@Parameter(hidden = true) final String apiRequestBodyAsJson) {
+        this.context.authenticatedUser().validateHasCreatePermission(this.resourceNameForPermissions);
+
+        final CommandWrapper commandRequest = new CommandWrapperBuilder() //
+                .createPaeDocuments() //
+                .withJson(apiRequestBodyAsJson) //
+                .build();
+
+        final CommandProcessingResult commandProcessingResult = this.commandsSourceWritePlatformService.logCommandSource(commandRequest);
+
+        return this.resultSerializer.serialize(commandProcessingResult);
+    }
+
+    @DELETE
+    @Path("{documentId}")
+    @Consumes({ MediaType.APPLICATION_JSON })
+    @Produces({ MediaType.APPLICATION_JSON })
+    @Operation(summary = "Delete a required document")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK", content = @Content(schema = @Schema(implementation = PaeRequiredDocumentationApiResourceSwagger.DeletePaeRequiredDocumentResponse.class))) })
+    public String deleteRequiredDocument(@PathParam("documentId") @Parameter(description = "documentId", required = true) Long documentId) {
+        this.context.authenticatedUser().validateHasPermissionTo("DELETE_" + this.resourceNameForPermissions);
+
+        final CommandWrapper commandRequest = new CommandWrapperBuilder() //
+                .deletePaeDocuments(documentId) //
+                .build();
+
+        final CommandProcessingResult commandProcessingResult = this.commandsSourceWritePlatformService.logCommandSource(commandRequest);
+
+        return this.resultSerializer.serialize(commandProcessingResult);
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/paedocumentation/api/PaeRequiredDocumentationApiResourceSwagger.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/paedocumentation/api/PaeRequiredDocumentationApiResourceSwagger.java
@@ -1,0 +1,95 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.organisation.paedocumentation.api;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.apache.fineract.organisation.paedocumentation.data.PaeRequiredDocumentData;
+
+final class PaeRequiredDocumentationApiResourceSwagger {
+
+    private PaeRequiredDocumentationApiResourceSwagger() {
+
+    }
+
+    @Schema(description = "PaeRequiredDocumentsResponse")
+    static final class GetPaeRequiredDocumentsResponse {
+
+        private GetPaeRequiredDocumentsResponse() {}
+
+        @Schema(example = "1")
+        public Long id;
+
+        @Schema(example = "1")
+        public Long categoryId;
+
+        @Schema(example = "ID Document")
+        public String documentName;
+
+        @Schema(example = "Copy of national ID")
+        public String description;
+
+        @Schema(example = "PDF,JPEG")
+        public String acceptedFormat;
+    }
+
+    @Schema(description = "PostPaeRequiredDocumentRequest")
+    static final class PostPaeRequiredDocumentRequest {
+
+        private PostPaeRequiredDocumentRequest() {}
+
+        @Schema(example = "1")
+        public Long categoryId;
+
+        @Schema(example = "ID Document")
+        public String documentName;
+
+        @Schema(example = "Copy of national ID")
+        public String description;
+
+        @Schema(example = "PDF,JPEG")
+        public String acceptedFormat;
+    }
+
+    @Schema(description = "PostPaeRequiredDocumentResponse")
+    static final class PostPaeRequiredDocumentResponse {
+
+        private PostPaeRequiredDocumentResponse() {}
+
+        @Schema(example = "1")
+        public Long resourceId;
+    }
+
+    @Schema(description = "GetPaeRequiredDocumentsListResponse")
+    static final class GetPaeRequiredDocumentsListResponse {
+
+        private GetPaeRequiredDocumentsListResponse() {}
+
+        public List<PaeRequiredDocumentData> documents;
+    }
+
+    @Schema(description = "DeletePaeRequiredDocumentResponse")
+    static final class DeletePaeRequiredDocumentResponse {
+
+        private DeletePaeRequiredDocumentResponse() {}
+
+        @Schema(example = "1")
+        public Long resourceId;
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/paedocumentation/data/PaeRequiredDocumentCommand.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/paedocumentation/data/PaeRequiredDocumentCommand.java
@@ -1,0 +1,72 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.organisation.paedocumentation.data;
+
+public class PaeRequiredDocumentCommand {
+
+    private Long categoryId;
+    private String documentName;
+    private String description;
+    private Boolean required;
+    private String acceptedFormat;
+
+    public PaeRequiredDocumentCommand() {
+        // for JSON binding
+    }
+
+    public Long getCategoryId() {
+        return categoryId;
+    }
+
+    public void setCategoryId(Long categoryId) {
+        this.categoryId = categoryId;
+    }
+
+    public String getDocumentName() {
+        return documentName;
+    }
+
+    public void setDocumentName(String documentName) {
+        this.documentName = documentName;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public String getAcceptedFormat() {
+        return acceptedFormat;
+    }
+
+    public void setAcceptedFormat(String acceptedFormat) {
+        this.acceptedFormat = acceptedFormat;
+    }
+
+    public Boolean getRequired() {
+        return required;
+    }
+
+    public void setRequired(Boolean required) {
+        this.required = required;
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/paedocumentation/data/PaeRequiredDocumentData.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/paedocumentation/data/PaeRequiredDocumentData.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.organisation.paedocumentation.data;
+
+public class PaeRequiredDocumentData {
+
+    private final Long id;
+    private final Long categoryId;
+    private final String documentName;
+    private final String description;
+    private final String acceptedFormat;
+    private final Boolean required;
+
+    public PaeRequiredDocumentData(Long id, Long categoryId, String documentName, String description, String acceptedFormat,
+            Boolean required) {
+        this.id = id;
+        this.categoryId = categoryId;
+        this.documentName = documentName;
+        this.description = description;
+        this.acceptedFormat = acceptedFormat;
+        this.required = required;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getCategoryId() {
+        return categoryId;
+    }
+
+    public String getDocumentName() {
+        return documentName;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getAcceptedFormat() {
+        return acceptedFormat;
+    }
+
+    public Boolean getRequired() {
+        return required;
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/paedocumentation/domain/PaeRequiredDocument.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/paedocumentation/domain/PaeRequiredDocument.java
@@ -1,0 +1,97 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.organisation.paedocumentation.domain;
+
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import lombok.Getter;
+import org.apache.fineract.infrastructure.codes.domain.CodeValue;
+import org.apache.fineract.infrastructure.core.domain.AbstractPersistableCustom;
+
+@Entity
+@Table(name = "pae_required_documents")
+public class PaeRequiredDocument extends AbstractPersistableCustom {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id", nullable = false)
+    private CodeValue category;
+
+    @Column(name = "document_name", nullable = false, length = 255)
+    private String documentName;
+
+    @Column(name = "description", length = 500)
+    private String description;
+
+    @Column(name = "accepted_format", length = 100)
+    private String acceptedFormat;
+
+    @Getter
+    @Column(name = "required")
+    private Boolean required;
+
+    @Column(name = "created_by")
+    private Long createdBy;
+
+    @Column(name = "created_on")
+    private LocalDateTime createdOn;
+
+    protected PaeRequiredDocument() {
+        // for JPA
+    }
+
+    public PaeRequiredDocument(CodeValue category, String documentName, String description, String acceptedFormat, Boolean required,
+            Long createdBy, LocalDateTime createdOn) {
+        this.category = category;
+        this.documentName = documentName;
+        this.description = description;
+        this.acceptedFormat = acceptedFormat;
+        this.required = required;
+        this.createdBy = createdBy;
+        this.createdOn = createdOn;
+    }
+
+    public CodeValue getCategory() {
+        return category;
+    }
+
+    public String getDocumentName() {
+        return documentName;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getAcceptedFormat() {
+        return acceptedFormat;
+    }
+
+    public Long getCreatedBy() {
+        return createdBy;
+    }
+
+    public LocalDateTime getCreatedOn() {
+        return createdOn;
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/paedocumentation/domain/PaeRequiredDocumentRepository.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/paedocumentation/domain/PaeRequiredDocumentRepository.java
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.organisation.paedocumentation.domain;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PaeRequiredDocumentRepository extends JpaRepository<PaeRequiredDocument, Long> {
+
+    List<PaeRequiredDocument> findByCategory_Id(Long categoryId);
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/paedocumentation/exception/PaeRequiredDocumentNotFoundException.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/paedocumentation/exception/PaeRequiredDocumentNotFoundException.java
@@ -1,0 +1,28 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.organisation.paedocumentation.exception;
+
+import org.apache.fineract.infrastructure.core.exception.AbstractPlatformResourceNotFoundException;
+
+public class PaeRequiredDocumentNotFoundException extends AbstractPlatformResourceNotFoundException {
+
+    public PaeRequiredDocumentNotFoundException(Long id) {
+        super("error.msg.pae.required.document.not.found", "PAE required document with id " + id + " not found", id);
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/paedocumentation/handler/CreatePaeRequiredDocumentCommandHandler.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/paedocumentation/handler/CreatePaeRequiredDocumentCommandHandler.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.organisation.paedocumentation.handler;
+
+import org.apache.fineract.commands.annotation.CommandType;
+import org.apache.fineract.commands.handler.NewCommandSourceHandler;
+import org.apache.fineract.infrastructure.core.api.JsonCommand;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.apache.fineract.organisation.paedocumentation.service.PaeRequiredDocumentWritePlatformService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@CommandType(entity = "PAE_DOCUMENTS", action = "ADD")
+public class CreatePaeRequiredDocumentCommandHandler implements NewCommandSourceHandler {
+
+    private final PaeRequiredDocumentWritePlatformService writePlatformService;
+
+    @Autowired
+    public CreatePaeRequiredDocumentCommandHandler(PaeRequiredDocumentWritePlatformService writePlatformService) {
+        this.writePlatformService = writePlatformService;
+    }
+
+    @Transactional
+    @Override
+    public CommandProcessingResult processCommand(JsonCommand command) {
+        return this.writePlatformService.create(command);
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/paedocumentation/handler/DeletePaeRequiredDocumentCommandHandler.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/paedocumentation/handler/DeletePaeRequiredDocumentCommandHandler.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.organisation.paedocumentation.handler;
+
+import org.apache.fineract.commands.annotation.CommandType;
+import org.apache.fineract.commands.handler.NewCommandSourceHandler;
+import org.apache.fineract.infrastructure.core.api.JsonCommand;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.apache.fineract.organisation.paedocumentation.service.PaeRequiredDocumentWritePlatformService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@CommandType(entity = "PAE_DOCUMENTS", action = "DELETE")
+public class DeletePaeRequiredDocumentCommandHandler implements NewCommandSourceHandler {
+
+    private final PaeRequiredDocumentWritePlatformService writePlatformService;
+
+    @Autowired
+    public DeletePaeRequiredDocumentCommandHandler(PaeRequiredDocumentWritePlatformService writePlatformService) {
+        this.writePlatformService = writePlatformService;
+    }
+
+    @Transactional
+    @Override
+    public CommandProcessingResult processCommand(JsonCommand command) {
+        return this.writePlatformService.delete(command.entityId());
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/paedocumentation/service/PaeRequiredDocumentReadPlatformService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/paedocumentation/service/PaeRequiredDocumentReadPlatformService.java
@@ -1,0 +1,27 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.organisation.paedocumentation.service;
+
+import java.util.List;
+import org.apache.fineract.organisation.paedocumentation.data.PaeRequiredDocumentData;
+
+public interface PaeRequiredDocumentReadPlatformService {
+
+    List<PaeRequiredDocumentData> retrieveByCategory(Long categoryId);
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/paedocumentation/service/PaeRequiredDocumentReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/paedocumentation/service/PaeRequiredDocumentReadPlatformServiceImpl.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.organisation.paedocumentation.service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.fineract.organisation.paedocumentation.data.PaeRequiredDocumentData;
+import org.apache.fineract.organisation.paedocumentation.domain.PaeRequiredDocument;
+import org.apache.fineract.organisation.paedocumentation.domain.PaeRequiredDocumentRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PaeRequiredDocumentReadPlatformServiceImpl implements PaeRequiredDocumentReadPlatformService {
+
+    private final PaeRequiredDocumentRepository repository;
+
+    public PaeRequiredDocumentReadPlatformServiceImpl(PaeRequiredDocumentRepository repository) {
+        this.repository = repository;
+    }
+
+    @Override
+    public List<PaeRequiredDocumentData> retrieveByCategory(Long categoryId) {
+        List<PaeRequiredDocument> entities = repository.findByCategory_Id(categoryId);
+        return entities.stream().map(e -> new PaeRequiredDocumentData(e.getId(), e.getCategory().getId(), e.getDocumentName(),
+                e.getDescription(), e.getAcceptedFormat(), e.getRequired())).collect(Collectors.toList());
+    }
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/paedocumentation/service/PaeRequiredDocumentWritePlatformService.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/paedocumentation/service/PaeRequiredDocumentWritePlatformService.java
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.organisation.paedocumentation.service;
+
+import org.apache.fineract.infrastructure.core.api.JsonCommand;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+
+public interface PaeRequiredDocumentWritePlatformService {
+
+    CommandProcessingResult create(JsonCommand command);
+
+    CommandProcessingResult delete(Long documentId);
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/paedocumentation/service/PaeRequiredDocumentWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/paedocumentation/service/PaeRequiredDocumentWritePlatformServiceJpaRepositoryImpl.java
@@ -1,0 +1,152 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.organisation.paedocumentation.service;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.PersistenceException;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.fineract.infrastructure.codes.domain.CodeValue;
+import org.apache.fineract.infrastructure.codes.domain.CodeValueRepositoryWrapper;
+import org.apache.fineract.infrastructure.core.api.JsonCommand;
+import org.apache.fineract.infrastructure.core.data.ApiParameterError;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResult;
+import org.apache.fineract.infrastructure.core.data.CommandProcessingResultBuilder;
+import org.apache.fineract.infrastructure.core.exception.PlatformApiDataValidationException;
+import org.apache.fineract.infrastructure.core.exception.PlatformDataIntegrityException;
+import org.apache.fineract.infrastructure.core.service.DateUtils;
+import org.apache.fineract.infrastructure.security.service.PlatformSecurityContext;
+import org.apache.fineract.organisation.paedocumentation.domain.PaeRequiredDocument;
+import org.apache.fineract.organisation.paedocumentation.domain.PaeRequiredDocumentRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.orm.jpa.JpaSystemException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class PaeRequiredDocumentWritePlatformServiceJpaRepositoryImpl implements PaeRequiredDocumentWritePlatformService {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PaeRequiredDocumentWritePlatformServiceJpaRepositoryImpl.class);
+
+    private final PlatformSecurityContext context;
+    private final PaeRequiredDocumentRepository repository;
+    private final CodeValueRepositoryWrapper codeValueRepositoryWrapper;
+
+    public PaeRequiredDocumentWritePlatformServiceJpaRepositoryImpl(PlatformSecurityContext context,
+            PaeRequiredDocumentRepository repository, CodeValueRepositoryWrapper codeValueRepositoryWrapper) {
+        this.context = context;
+        this.repository = repository;
+        this.codeValueRepositoryWrapper = codeValueRepositoryWrapper;
+    }
+
+    @Override
+    @Transactional
+    public CommandProcessingResult create(JsonCommand command) {
+        this.context.authenticatedUser();
+
+        try {
+            validateForCreate(command);
+
+            final Long categoryId = command.longValueOfParameterNamed("categoryId");
+            final String documentName = command.stringValueOfParameterNamed("documentName");
+            final String description = command.stringValueOfParameterNamed("description");
+            final boolean required = command.booleanPrimitiveValueOfParameterNamed("required");
+            final String acceptedFormat = command.stringValueOfParameterNamed("acceptedFormat");
+
+            CodeValue category = this.codeValueRepositoryWrapper.findOneWithNotFoundDetection(categoryId);
+
+            Long createdBy = this.context.authenticatedUser().getId();
+            LocalDateTime createdOn = DateUtils.getLocalDateTimeOfSystem();
+
+            PaeRequiredDocument entity = new PaeRequiredDocument(category, documentName, description, acceptedFormat, required, createdBy,
+                    createdOn);
+            entity = this.repository.saveAndFlush(entity);
+
+            return new CommandProcessingResultBuilder() //
+                    .withCommandId(command.commandId()) //
+                    .withEntityId(entity.getId()) //
+                    .build();
+        } catch (final JpaSystemException | DataIntegrityViolationException dve) {
+            handleDataIntegrityIssues(command, dve.getMostSpecificCause(), dve);
+            return CommandProcessingResult.empty();
+        } catch (final PersistenceException dve) {
+            Throwable throwable = ExceptionUtils.getRootCause(dve.getCause());
+            handleDataIntegrityIssues(command, throwable, dve);
+            return CommandProcessingResult.empty();
+        }
+    }
+
+    @Override
+    @Transactional
+    public CommandProcessingResult delete(Long documentId) {
+        this.context.authenticatedUser();
+        PaeRequiredDocument entity = this.repository.findById(documentId)
+                .orElseThrow(() -> new PlatformDataIntegrityException("error.msg.pae.required.document.not.found",
+                        "PAE required document with id " + documentId + " not found", documentId));
+
+        this.repository.delete(entity);
+        this.repository.flush();
+
+        return new CommandProcessingResultBuilder() //
+                .withEntityId(documentId) //
+                .build();
+    }
+
+    private void validateForCreate(JsonCommand command) {
+        final List<ApiParameterError> dataValidationErrors = new ArrayList<>();
+
+        final Long categoryId = command.longValueOfParameterNamed("categoryId");
+        if (categoryId == null || categoryId <= 0) {
+            dataValidationErrors.add(ApiParameterError.parameterError("validation.msg.pae.required.document.categoryId.invalid",
+                    "The categoryId parameter is required and must be greater than zero", "categoryId", categoryId));
+        }
+
+        final String documentName = command.stringValueOfParameterNamed("documentName");
+        if (StringUtils.isBlank(documentName)) {
+            dataValidationErrors.add(ApiParameterError.parameterError("validation.msg.pae.required.document.documentName.cannot.be.blank",
+                    "The documentName parameter is required", "documentName", documentName));
+        } else if (documentName.length() > 255) {
+            dataValidationErrors
+                    .add(ApiParameterError.parameterError("validation.msg.pae.required.document.documentName.exceeds.max.length",
+                            "The documentName parameter exceeds max length of 255 characters", "documentName", documentName));
+        }
+
+        final String acceptedFormat = command.stringValueOfParameterNamed("acceptedFormat");
+        if (acceptedFormat != null && acceptedFormat.length() > 100) {
+            dataValidationErrors
+                    .add(ApiParameterError.parameterError("validation.msg.pae.required.document.acceptedFormat.exceeds.max.length",
+                            "The acceptedFormat parameter exceeds max length of 100 characters", "acceptedFormat", acceptedFormat));
+        }
+
+        if (!dataValidationErrors.isEmpty()) {
+            throw new PlatformApiDataValidationException("validation.msg.pae.required.document.validation.errors.exist",
+                    "Validation errors exist for creating PAE required document", dataValidationErrors);
+        }
+    }
+
+    private void handleDataIntegrityIssues(final JsonCommand command, final Throwable realCause, final Exception dve) {
+        LOG.error("Error occurred while creating PAE required document", dve);
+        throw new PlatformDataIntegrityException("error.msg.pae.required.document.unknown.data.integrity.issue",
+                "Unknown data integrity issue with PAE required document resource: " + realCause.getMessage());
+    }
+}

--- a/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/changelog-tenant.xml
@@ -174,4 +174,5 @@
     <include file="parts/0150-PUENTE_AL_EXITO_RENEGOTIATIONS.xml" relativeToChangelogFile="true"/>
     <include file="parts/PUE_20_11_25_add_limit_amount_settings.xml" relativeToChangelogFile="true"/>
     <include file="parts/PUE_27_11_25_ADD_PAE_REQUIRED_GUARANTEES.xml" relativeToChangelogFile="true"/>
+    <include file="parts/PUE_28_11_25_ADD_PAE_REQUIRED_DOCUMENTS.xml" relativeToChangelogFile="true"/>
 </databaseChangeLog>

--- a/fineract-provider/src/main/resources/db/changelog/tenant/parts/PUE_28_11_25_ADD_PAE_REQUIRED_DOCUMENTS.xml
+++ b/fineract-provider/src/main/resources/db/changelog/tenant/parts/PUE_28_11_25_ADD_PAE_REQUIRED_DOCUMENTS.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements. See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership. The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied. See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+    <changeSet id="PUE_28_11_25_ADD_PAE_REQUIRED_DOCUMENTS" author="brian">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="pae_required_documents"/>
+            </not>
+        </preConditions>
+        <createTable tableName="pae_required_documents">
+            <column name="id" type="BIGINT" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false" primaryKeyName="pk_pae_required_documents"/>
+            </column>
+            <column name="category_id" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="document_name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="description" type="VARCHAR(500)"/>
+            <column name="accepted_format" type="VARCHAR(100)"/>
+            <column name="created_by" type="BIGINT"/>
+            <column name="created_on" type="DATETIME"/>
+        </createTable>
+
+        <addForeignKeyConstraint baseTableName="pae_required_documents"
+                                  baseColumnNames="category_id"
+                                  referencedTableName="m_code_value"
+                                  referencedColumnNames="id"
+                                  constraintName="fk_pae_required_documents_category_id_m_code_value"/>
+
+        <createIndex tableName="pae_required_documents" indexName="idx_pae_required_documents_category_id">
+            <column name="category_id"/>
+        </createIndex>
+    </changeSet>
+
+    <changeSet id="PUE_29_11_25_ADD_PAE_DOCUMENT_PERMISSIONS" author="brian">
+        <preConditions onFail="MARK_RAN">
+                <sqlCheck expectedResult="0">
+                    <![CDATA[
+                        SELECT COUNT(*) FROM m_permission
+                        WHERE code IN ('READ_PAE_DOCUMENTS', 'ADD_PAE_DOCUMENTS', 'DELETE_PAE_DOCUMENTS')
+                    ]]>
+                </sqlCheck>
+        </preConditions>
+
+        <insert tableName="m_permission">
+            <column name="grouping" value="organisation"/>
+            <column name="code" value="READ_PAE_DOCUMENTS"/>
+            <column name="entity_name" value="PAE_DOCUMENTS"/>
+            <column name="action_name" value="READ"/>
+            <column name="can_maker_checker" valueBoolean="false"/>
+        </insert>
+
+        <insert tableName="m_permission">
+            <column name="grouping" value="organisation"/>
+            <column name="code" value="ADD_PAE_DOCUMENTS"/>
+            <column name="entity_name" value="PAE_DOCUMENTS"/>
+            <column name="action_name" value="CREATE"/>
+            <column name="can_maker_checker" valueBoolean="false"/>
+        </insert>
+
+        <insert tableName="m_permission">
+            <column name="grouping" value="organisation"/>
+            <column name="code" value="DELETE_PAE_DOCUMENTS"/>
+            <column name="entity_name" value="PAE_DOCUMENTS"/>
+            <column name="action_name" value="DELETE"/>
+            <column name="can_maker_checker" valueBoolean="false"/>
+        </insert>
+    </changeSet>
+
+    <changeSet id="PUE_28_11_25_ADD_PAE_REQUIRED_DOCUMENTS_2" author="brian">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="pae_required_documents" columnName="required"/>
+            </not>
+        </preConditions>
+        <addColumn tableName="pae_required_documents">
+            <column name="required" type="BOOLEAN" defaultValueBoolean="true">
+                <constraints nullable="false"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
This pull request introduces a new feature for managing PAE (Prescribed Asset Exposure) required documents, including full CRUD support via API endpoints, persistence, and supporting infrastructure. The changes add a new domain model, API resource, data transfer objects, repository, exception handling, and command handlers to support creating and deleting required documents for PAE by category.

The most important changes are:

**API Layer:**

* Added `PaeRequiredDocumentationApiResource` to expose endpoints for listing, creating, and deleting PAE required documents by category, with OpenAPI documentation and permission checks. (`PaeRequiredDocumentationApiResource.java`)
* Added Swagger/OpenAPI schema definitions for request and response payloads for the new API. (`PaeRequiredDocumentationApiResourceSwagger.java`)

**Domain & Persistence:**

* Introduced `PaeRequiredDocument` JPA entity to represent required documents, including fields for category, name, description, format, and audit info. (`PaeRequiredDocument.java`)
* Added Spring Data JPA repository for querying documents by category. (`PaeRequiredDocumentRepository.java`)

**Data Transfer & Command Handling:**

* Added DTOs for document data and commands: `PaeRequiredDocumentData` and `PaeRequiredDocumentCommand`. (`PaeRequiredDocumentData.java`, `PaeRequiredDocumentCommand.java`)

* Implemented command handlers for creating and deleting required documents, and integrated with the command framework. (`CreatePaeRequiredDocumentCommandHandler.java`, `CommandWrapperBuilder.java`)

**Error Handling:**

* Added a custom exception for not found errors when accessing required documents. (`PaeRequiredDocumentNotFoundException.java`)