### PR TITLE
Feature/puente al exito

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/codes/data/CodeValueData.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/codes/data/CodeValueData.java
@@ -79,8 +79,8 @@ public class CodeValueData implements Serializable {
         return new CodeValueData(id, name, position, description, isActive, mandatory);
     }
 
-    private CodeValueData(final Long id, final String name, final Integer position, final String description, final boolean active,
-            final boolean mandatory) {
+    protected CodeValueData(final Long id, final String name, final Integer position, final String description, final boolean active,
+                            final boolean mandatory) {
         this.id = id;
         this.name = name;
         this.position = position;

--- a/fineract-provider/src/main/java/org/apache/fineract/infrastructure/codes/data/CodeValueDataExtended.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/infrastructure/codes/data/CodeValueDataExtended.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.fineract.infrastructure.codes.data;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.fineract.organisation.paedocumentation.data.PaeRequiredDocumentData;
+
+import java.util.Collection;
+
+/**
+ * Immutable data object represent code-value data in system.
+ */
+public class CodeValueDataExtended extends CodeValueData {
+    @Getter @Setter
+    private Collection<PaeRequiredDocumentData> extraData;
+
+    public CodeValueDataExtended(Long id) {
+        super(id);
+    }
+
+    public static CodeValueDataExtended instance(final Long id, final String name, final Integer position, final String description,
+                                         final boolean isActive, final boolean mandatory) {
+        return new CodeValueDataExtended(id, name, position, description, isActive, mandatory);
+    }
+
+    private CodeValueDataExtended(final Long id, final String name, final Integer position, final String description, final boolean active,
+                          final boolean mandatory) {
+        super(id, name, position, description, active, mandatory);
+    }
+
+}

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/data/LoanAccountData.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/data/LoanAccountData.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import javax.persistence.Transient;
 import lombok.Getter;
 import org.apache.fineract.infrastructure.codes.data.CodeValueData;
+import org.apache.fineract.infrastructure.codes.data.CodeValueDataExtended;
 import org.apache.fineract.infrastructure.core.data.EnumOptionData;
 import org.apache.fineract.infrastructure.dataqueries.data.DatatableData;
 import org.apache.fineract.organisation.agency.data.AgencyData;
@@ -286,7 +287,7 @@ public final class LoanAccountData {
     private Collection<CodeValueData> cancellationReasonOptions;
     private GroupLoanAdditionalData groupLoanAdditionalData;
     private List<EconomicSectorData> economicSectorOptions;
-    private Collection<CodeValueData> paeRequiredGuaranteeOptions;
+    private Collection<CodeValueDataExtended> paeRequiredGuaranteeOptions;
 
     public static LoanAccountData disburseLoanByCheques(final Collection<AgencyData> agencyOptions,
             final Collection<CenterData> centerOptions, final Collection<GroupGeneralData> groupOption,
@@ -1430,7 +1431,7 @@ public final class LoanAccountData {
             final Collection<FundData> fundOptions, final Collection<ChargeData> chargeOptions,
             final Collection<CodeValueData> loanPurposeOptions, final Collection<CodeValueData> loanCollateralOptions,
             final Integer loanCycleNumber, final Collection<LoanAccountSummaryData> clientActiveLoanOptions,
-            Collection<CodeValueData> paeRequiredGuaranteeOptions) {
+            Collection<CodeValueDataExtended> paeRequiredGuaranteeOptions) {
 
         final Long id = null;
         final String accountNo = null;
@@ -2101,7 +2102,7 @@ public final class LoanAccountData {
             final Collection<GroupGeneralData> groupOptions, final Collection<AppUserData> facilitatorOptions,
             final Collection<EnumOptionData> disbursementMethodOptions, BigDecimal requiredGuaranteeAmount,
             final BigDecimal actualGuaranteeAmount, GroupLoanAdditionalData groupLoanAdditionalData,
-            Collection<CodeValueData> paeRequiredGuaranteeOptions) {
+            Collection<CodeValueDataExtended> paeRequiredGuaranteeOptions) {
 
         this.id = id;
         this.accountNo = accountNo;

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanReadPlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanReadPlatformServiceImpl.java
@@ -35,11 +35,13 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.fineract.accounting.common.AccountingRuleType;
 import org.apache.fineract.infrastructure.codes.data.CodeValueData;
+import org.apache.fineract.infrastructure.codes.data.CodeValueDataExtended;
 import org.apache.fineract.infrastructure.codes.domain.CodeValue;
 import org.apache.fineract.infrastructure.codes.domain.CodeValueRepositoryWrapper;
 import org.apache.fineract.infrastructure.codes.service.CodeValueReadPlatformService;
@@ -63,6 +65,8 @@ import org.apache.fineract.organisation.monetary.domain.ApplicationCurrency;
 import org.apache.fineract.organisation.monetary.domain.ApplicationCurrencyRepositoryWrapper;
 import org.apache.fineract.organisation.monetary.domain.MonetaryCurrency;
 import org.apache.fineract.organisation.monetary.domain.Money;
+import org.apache.fineract.organisation.paedocumentation.data.PaeRequiredDocumentData;
+import org.apache.fineract.organisation.paedocumentation.service.PaeRequiredDocumentReadPlatformService;
 import org.apache.fineract.organisation.prequalification.data.GroupPrequalificationData;
 import org.apache.fineract.organisation.prequalification.data.LoanAdditionalData;
 import org.apache.fineract.organisation.prequalification.domain.LoanAdditionProperties;
@@ -184,6 +188,7 @@ public class LoanReadPlatformServiceImpl implements LoanReadPlatformService {
     private final LoanAdditionalPropertiesRepository loanAdditionalPropertiesRepository;
     private final AgencyReadPlatformService agencyReadPlatformService;
     private final PrequalificationReadPlatformServiceImpl.PrequalificationIndividualMappingsMapper prequalificationIndividualMappingsMapper = new PrequalificationReadPlatformServiceImpl.PrequalificationIndividualMappingsMapper();
+    private final PaeRequiredDocumentReadPlatformService paeRequiredDocumentReadPlatformService;
 
     @Autowired
     public LoanReadPlatformServiceImpl(final PlatformSecurityContext context,
@@ -199,7 +204,8 @@ public class LoanReadPlatformServiceImpl implements LoanReadPlatformService {
             final ConfigurationDomainService configurationDomainService, final CodeValueRepositoryWrapper codeValueRepositoryWrapper,
             final AccountDetailsReadPlatformService accountDetailsReadPlatformService, final LoanRepositoryWrapper loanRepositoryWrapper,
             final ColumnValidator columnValidator, DatabaseSpecificSQLGenerator sqlGenerator, PaginationHelper paginationHelper,
-            LoanAdditionalPropertiesRepository loanAdditionalPropertiesRepository, AgencyReadPlatformService agencyReadPlatformService) {
+            LoanAdditionalPropertiesRepository loanAdditionalPropertiesRepository, AgencyReadPlatformService agencyReadPlatformService,
+            PaeRequiredDocumentReadPlatformService paeRequiredDocumentReadPlatformService) {
         this.context = context;
         this.loanRepositoryWrapper = loanRepositoryWrapper;
         this.applicationCurrencyRepository = applicationCurrencyRepository;
@@ -227,6 +233,7 @@ public class LoanReadPlatformServiceImpl implements LoanReadPlatformService {
         this.codeValueRepositoryWrapper = codeValueRepositoryWrapper;
         this.loanAdditionalPropertiesRepository = loanAdditionalPropertiesRepository;
         this.agencyReadPlatformService = agencyReadPlatformService;
+        this.paeRequiredDocumentReadPlatformService = paeRequiredDocumentReadPlatformService;
     }
 
     @Override
@@ -1649,17 +1656,25 @@ public class LoanReadPlatformServiceImpl implements LoanReadPlatformService {
             activeLoanOptions = this.accountDetailsReadPlatformService.retrieveGroupActiveLoanAccountSummary(groupId);
         }
         // for product that is PAE add the required guarantee options
-        Collection<CodeValueData> paeRequiredGuaranteeOptions = null;
+        Collection<CodeValueDataExtended> paeRequiredGuaranteeDocuments = null;
         if (loanProduct.getOwnerTypeOption() != null
                 && loanProduct.getOwnerTypeOption().getId().intValue() == LoanProductOwnerType.PAE.getValue()) {
-            paeRequiredGuaranteeOptions = this.codeValueReadPlatformService.retrieveCodeValuesByCode("PaeRequiredGuarantees");
+            Collection<CodeValueData> paeRequiredGuarantees = this.codeValueReadPlatformService.retrieveCodeValuesByCode("PaeRequiredGuarantees");
+            if (!paeRequiredGuarantees.isEmpty()) paeRequiredGuaranteeDocuments = new ArrayList<>();
+            for (CodeValueData codeValue : Objects.requireNonNull(paeRequiredGuarantees)) {
+                List<PaeRequiredDocumentData> documentsList = this.paeRequiredDocumentReadPlatformService.retrieveByCategory(codeValue.getId());
+                CodeValueDataExtended cartegoryDocuments= CodeValueDataExtended.instance(codeValue.getId(),codeValue.getName(),codeValue.getPosition(),
+                        codeValue.getDescription(),codeValue.isActive(), codeValue.isMandatory());
+                cartegoryDocuments.setExtraData(documentsList);
+                paeRequiredGuaranteeDocuments.add(cartegoryDocuments);
+            }
         }
 
         return LoanAccountData.loanProductWithTemplateDefaults(loanProduct, loanTermFrequencyTypeOptions, repaymentFrequencyTypeOptions,
                 repaymentFrequencyNthDayTypeOptions, repaymentFrequencyDaysOfWeekTypeOptions, repaymentStrategyOptions,
                 interestRateFrequencyTypeOptions, amortizationTypeOptions, interestTypeOptions, interestCalculationPeriodTypeOptions,
                 fundOptions, chargeOptions, loanPurposeOptions, loanCollateralOptions, loanCycleCounter, activeLoanOptions,
-                paeRequiredGuaranteeOptions);
+                paeRequiredGuaranteeDocuments);
     }
 
     @Override


### PR DESCRIPTION
This pull request introduces an extended data model for code values related to PAE required guarantees in loan accounts, allowing for the inclusion of additional document data. The main changes involve the creation of a new `CodeValueDataExtended` class, updates to the data types in `LoanAccountData`, and enhancements to the loan product retrieval logic to populate extra document information.

**Data Model Enhancements:**
- Added a new `CodeValueDataExtended` class that extends `CodeValueData` to include an `extraData` field for holding associated `PaeRequiredDocumentData` documents.
- Changed the constructor visibility of `CodeValueData` from private to protected to allow subclassing.

**Loan Account Data Updates:**
- Updated the `paeRequiredGuaranteeOptions` field and related method parameters in `LoanAccountData` to use `Collection<CodeValueDataExtended>` instead of the base type, enabling storage of extra document data
- Imported `CodeValueDataExtended` where necessary to support the new data type.

**Service Layer and Business Logic Changes:**
- Injected and used `PaeRequiredDocumentReadPlatformService` in `LoanReadPlatformServiceImpl` to retrieve documents associated with each required guarantee code value.
- Enhanced the `retrieveLoanProductDetailsTemplate` method to build and populate the extended guarantee options with their associated documents, using the new `CodeValueDataExtended` class.
