### PR TITLE
Add prequalification loan checks and retrieval methods in loan services

### DIFF
--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/paedocumentation/api/PaeRequiredDocumentationApiResource.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/paedocumentation/api/PaeRequiredDocumentationApiResource.java
@@ -167,8 +167,8 @@ public class PaeRequiredDocumentationApiResource {
             @FormDataParam("description") final String description, @FormDataParam("comment") final String comment) {
         if (inputStream != null) {
             fileUploadValidator.validate(fileSize, inputStream, fileDetails, bodyPart);
-            final DocumentCommand documentCommand = new DocumentCommand(null, null, "paeloandocs", loanId, name,
-                    fileDetails.getFileName(), fileSize, bodyPart.getMediaType().toString(), description, null);
+            final DocumentCommand documentCommand = new DocumentCommand(null, null, "paeloandocs", loanId, name, fileDetails.getFileName(),
+                    fileSize, bodyPart.getMediaType().toString(), description, null);
             documentCommand.setDocumentType(categoryId);
             documentCommand.setDocumentPurpose(guaranteeNo);
             final Long documentId = this.documentWritePlatformService.createDocument(documentCommand, inputStream);

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/prequalification/exception/PrequalificationNotProvidedException.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/prequalification/exception/PrequalificationNotProvidedException.java
@@ -28,4 +28,8 @@ public class PrequalificationNotProvidedException extends AbstractPlatformResour
     public PrequalificationNotProvidedException() {
         super("error.msg.group.prequalification.is.not.provided", "Prequalification is a mandatory");
     }
+
+    public PrequalificationNotProvidedException(String s, String s1, Long prequalificationId) {
+        super(s, s1, prequalificationId);
+    }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/organisation/prequalification/service/PrequalificationWritePlatformServiceImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/organisation/prequalification/service/PrequalificationWritePlatformServiceImpl.java
@@ -108,6 +108,7 @@ import org.apache.fineract.portfolio.loanaccount.domain.GroupLoanAdditionals;
 import org.apache.fineract.portfolio.loanaccount.domain.GroupLoanAdditionalsRepository;
 import org.apache.fineract.portfolio.loanaccount.domain.Loan;
 import org.apache.fineract.portfolio.loanaccount.domain.LoanRepositoryWrapper;
+import org.apache.fineract.portfolio.loanaccount.exception.LoanNotFoundException;
 import org.apache.fineract.portfolio.loanaccount.service.LoanApplicationWritePlatformService;
 import org.apache.fineract.portfolio.loanproduct.domain.LoanProduct;
 import org.apache.fineract.portfolio.loanproduct.domain.LoanProductOwnerType;
@@ -995,7 +996,11 @@ public class PrequalificationWritePlatformServiceImpl implements Prequalificatio
             prequalificationStatus = PrequalificationStatus.fromInt(statusRange);
             if (prequalificationStatus.equals(PrequalificationStatus.COMPLETED)) {
                 reportToPrint = "Commitee Approval Report";
-                Loan loan = this.loanRepositoryWrapper.retrieveByPrequalificationId(entityId);
+                List<Loan> allLoans = this.loanRepositoryWrapper.retrieveAllByPrequalificationId(entityId);
+                if (allLoans.isEmpty()) {
+                    throw new LoanNotFoundException(loanId);
+                }
+                Loan loan = allLoans.get(0);
                 loanId = loan != null ? loan.getId() : null;
             }
         }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanRepository.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanRepository.java
@@ -194,4 +194,7 @@ public interface LoanRepository extends JpaRepository<Loan, Long>, JpaSpecificat
     @Query("SELECT lo FROM Loan lo WHERE lo.prequalificationGroup.id = :prequalificationId")
     Loan retrieveByPrequalificationId(@Param("prequalificationId") Long prequalificationId);
 
+    @Query("SELECT lo FROM Loan lo WHERE lo.prequalificationGroup.id = :prequalificationId order by lo.id desc")
+    List<Loan> retrieveAllByPrequalificationId(@Param("prequalificationId") Long prequalificationId);
+
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanRepositoryWrapper.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/domain/LoanRepositoryWrapper.java
@@ -273,4 +273,8 @@ public class LoanRepositoryWrapper {
     public Loan retrieveByPrequalificationId(@Param("prequalificationId") Long prequalificationId) {
         return this.repository.retrieveByPrequalificationId(prequalificationId);
     }
+
+    public List<Loan> retrieveAllByPrequalificationId(@Param("prequalificationId") Long prequalificationId) {
+        return this.repository.retrieveAllByPrequalificationId(prequalificationId);
+    }
 }

--- a/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanApplicationWritePlatformServiceJpaRepositoryImpl.java
+++ b/fineract-provider/src/main/java/org/apache/fineract/portfolio/loanaccount/service/LoanApplicationWritePlatformServiceJpaRepositoryImpl.java
@@ -430,6 +430,17 @@ public class LoanApplicationWritePlatformServiceJpaRepositoryImpl implements Loa
                         dataValidationErrors);
             }
 
+            final Long prequalificationId = this.fromJsonHelper.extractLongNamed("prequalificationId", command.parsedJson());
+
+            if (prequalificationId != null) {
+                String existingPendingLoan = "select count(*) from m_loan where prequalification_id = ? and loan_status_id =? ";
+                Long pendingLoanCount = this.jdbcTemplate.queryForObject(existingPendingLoan, Long.class, prequalificationId,
+                        LoanStatus.SUBMITTED_AND_PENDING_APPROVAL.getValue());
+                if (pendingLoanCount > 0) {
+                    throw new PrequalificationNotProvidedException("error.msg.loan.prequalification.pending.loan.exists",
+                            "The prequalification with id " + prequalificationId + " has a pending loan application.", prequalificationId);
+                }
+            }
             final Loan newLoanApplication = this.loanAssembler.assembleFrom(command);
 
             checkForProductMixRestrictions(newLoanApplication);


### PR DESCRIPTION
## 

**Prequalification and Loan Processing Improvements:**

* Added a check in `LoanApplicationWritePlatformServiceJpaRepositoryImpl` to prevent submission of a new loan application if there is already a pending loan for the same `prequalificationId`, throwing a `PrequalificationNotProvidedException` with a detailed message.
* Updated `PrequalificationWritePlatformServiceImpl` to retrieve all loans by `prequalificationId` and throw a `LoanNotFoundException` if none exist, ensuring correct error handling when processing analysis requests.
* Added a new repository method `retrieveAllByPrequalificationId` in both `LoanRepository` and `LoanRepositoryWrapper` to support fetching all loans associated with a prequalification group.

**Exception Handling Enhancements:**

* Enhanced `PrequalificationNotProvidedException` with a new constructor that allows passing custom error messages and the relevant prequalification ID for more descriptive error reporting.

**Minor Code and Dependency Updates:**

* Added import for `LoanNotFoundException` in `PrequalificationWritePlatformServiceImpl` to support new error handling logic.
* Minor formatting adjustment in the creation of `DocumentCommand` in `PaeRequiredDocumentationApiResource` for improved readability.